### PR TITLE
Add sample paper generation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 images/Thankyou.JPG filter=lfs diff=lfs merge=lfs -text
+sample_papers/** filter=lfs diff=lfs merge=lfs -text

--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -739,11 +739,6 @@
                                 <label for="genSubject">Subject</label>
                                 <select id="genSubject" class="form-control">
                                     <option value="">-- Select Subject --</option>
-                                    <option value="OS">Operating Systems</option>
-                                    <option value="DBMS">Database Systems</option>
-                                    <option value="DSA">Data Structures</option>
-                                    <option value="WT">Web Technologies</option>
-                                    <option value="ML">Machine Learning</option>
                                 </select>
                             </div>
                             
@@ -781,6 +776,9 @@
                         <button class="btn">
                             <i class="fas fa-cogs"></i> Generate Paper
                         </button>
+                        <a id="downloadSample" class="btn" href="#" style="display:none;" download>
+                            <i class="fas fa-download"></i> Download Sample
+                        </a>
                     </div>
                 </div>
                 
@@ -821,11 +819,6 @@
                                 <label for="upSubject">Subject</label>
                                 <select id="upSubject" class="form-control">
                                     <option value="">-- Select Subject --</option>
-                                    <option value="OS">Operating Systems</option>
-                                    <option value="DBMS">Database Systems</option>
-                                    <option value="DSA">Data Structures</option>
-                                    <option value="WT">Web Technologies</option>
-                                    <option value="ML">Machine Learning</option>
                                 </select>
                             </div>
                             
@@ -968,6 +961,89 @@
                 `;
             }
         }
+
+        // Subject database for dropdowns
+        const subjectsDatabase = {
+            "CSE": {
+                "1": ["Mathematics-I", "Engineering Physics", "Programming Fundamentals", "Engineering Graphics", "Environmental Science"],
+                "2": ["Data Structures & Algorithms", "Digital Logic Design", "Discrete Mathematics", "Object Oriented Programming", "Database Management Systems"],
+                "3": ["Operating Systems", "Computer Networks", "Software Engineering", "Theory of Computation", "Web Technologies", "Machine Learning"],
+                "4": ["Artificial Intelligence", "Cloud Computing", "Big Data Analytics", "Cybersecurity", "Internet of Things", "Project Work"]
+            },
+            "ECE": {
+                "1": ["Mathematics-I", "Engineering Chemistry", "Basic Electronics", "Engineering Graphics", "English Communication"],
+                "2": ["Signals and Systems", "Analog Circuits", "Digital Electronics", "Probability Theory", "Network Analysis"],
+                "3": ["Microprocessors", "Communication Systems", "Control Systems", "VLSI Design", "Embedded Systems"],
+                "4": ["Wireless Communication", "Optical Communication", "Microwave Engineering", "Antenna Theory", "Project Work"]
+            },
+            "MECH": {
+                "1": ["Mathematics-I", "Engineering Physics", "Engineering Mechanics", "Engineering Graphics", "Workshop Practice"],
+                "2": ["Thermodynamics", "Fluid Mechanics", "Strength of Materials", "Manufacturing Processes", "Machine Drawing"],
+                "3": ["Heat Transfer", "Dynamics of Machines", "Machine Design", "Industrial Engineering", "CAD/CAM"],
+                "4": ["Automobile Engineering", "Robotics", "Finite Element Analysis", "Refrigeration & Air Conditioning", "Project Work"]
+            },
+            "EEE": {
+                "1": ["Mathematics-I", "Engineering Chemistry", "Basic Electrical Engineering", "Engineering Graphics", "English Communication"],
+                "2": ["Circuit Theory", "Electromagnetic Fields", "Analog Electronics", "Digital Electronics", "Signals and Systems"],
+                "3": ["Power Systems", "Control Systems", "Electrical Machines", "Power Electronics", "Microprocessors"],
+                "4": ["High Voltage Engineering", "Renewable Energy Systems", "Electrical Drives", "Smart Grid", "Project Work"]
+            },
+            "CIVIL": {
+                "1": ["Mathematics-I", "Engineering Physics", "Engineering Mechanics", "Engineering Graphics", "Environmental Science"],
+                "2": ["Strength of Materials", "Fluid Mechanics", "Surveying", "Building Materials", "Engineering Geology"],
+                "3": ["Structural Analysis", "Geotechnical Engineering", "Transportation Engineering", "Water Resources Engineering", "Concrete Technology"],
+                "4": ["Environmental Engineering", "Design of Structures", "Construction Management", "Remote Sensing", "Project Work"]
+            }
+        };
+
+        function populateSubjects(yearSel, branchSel, subjectSel) {
+            const year = document.getElementById(yearSel).value;
+            const branch = document.getElementById(branchSel).value;
+            const subjectDropdown = document.getElementById(subjectSel);
+            subjectDropdown.innerHTML = '<option value="">-- Select Subject --</option>';
+            if (subjectsDatabase[branch] && subjectsDatabase[branch][year]) {
+                subjectsDatabase[branch][year].forEach(sub => {
+                    const opt = document.createElement('option');
+                    opt.value = sub;
+                    opt.textContent = sub;
+                    subjectDropdown.appendChild(opt);
+                });
+            }
+        }
+
+        function updateDownloadLink() {
+            const year = document.getElementById('genYear').value;
+            const branch = document.getElementById('genBranch').value;
+            const subject = document.getElementById('genSubject').value;
+            const type = document.getElementById('genType').value;
+            const link = document.getElementById('downloadSample');
+            if (year && branch && subject && type) {
+                const fileName = encodeURIComponent(subject.replace(/ /g, '_')) + '.pdf';
+                link.href = `sample_papers/${branch}/${year}/${type}/${fileName}`;
+                link.style.display = 'inline-block';
+            } else {
+                link.style.display = 'none';
+            }
+        }
+
+        document.getElementById('genYear').addEventListener('change', () => {
+            populateSubjects('genYear', 'genBranch', 'genSubject');
+            updateDownloadLink();
+        });
+        document.getElementById('genBranch').addEventListener('change', () => {
+            populateSubjects('genYear', 'genBranch', 'genSubject');
+            updateDownloadLink();
+        });
+        document.getElementById('genSubject').addEventListener('change', updateDownloadLink);
+        document.getElementById('genType').addEventListener('change', updateDownloadLink);
+
+        document.getElementById('upYear').addEventListener('change', () => populateSubjects('upYear', 'upBranch', 'upSubject'));
+        document.getElementById('upBranch').addEventListener('change', () => populateSubjects('upYear', 'upBranch', 'upSubject'));
+
+        // Initialize dropdowns on page load
+        populateSubjects('genYear', 'genBranch', 'genSubject');
+        populateSubjects('upYear', 'upBranch', 'upSubject');
+        updateDownloadLink();
         
         // Logout functionality - updated to match schedule.html
         document.getElementById('logoutBtn').addEventListener('click', function(e) {

--- a/generate_sample_papers.py
+++ b/generate_sample_papers.py
@@ -1,0 +1,121 @@
+import os
+import requests
+from tqdm import tqdm
+from fpdf import FPDF
+from git import Repo
+
+subjectsDatabase = {
+    "CSE": {
+        "1": ["Mathematics-I", "Engineering Physics", "Programming Fundamentals", "Engineering Graphics", "Environmental Science"],
+        "2": ["Data Structures & Algorithms", "Digital Logic Design", "Discrete Mathematics", "Object Oriented Programming", "Database Management Systems"],
+        "3": ["Operating Systems", "Computer Networks", "Software Engineering", "Theory of Computation", "Web Technologies", "Machine Learning"],
+        "4": ["Artificial Intelligence", "Cloud Computing", "Big Data Analytics", "Cybersecurity", "Internet of Things", "Project Work"]
+    },
+    "ECE": {
+        "1": ["Mathematics-I", "Engineering Chemistry", "Basic Electronics", "Engineering Graphics", "English Communication"],
+        "2": ["Signals and Systems", "Analog Circuits", "Digital Electronics", "Probability Theory", "Network Analysis"],
+        "3": ["Microprocessors", "Communication Systems", "Control Systems", "VLSI Design", "Embedded Systems"],
+        "4": ["Wireless Communication", "Optical Communication", "Microwave Engineering", "Antenna Theory", "Project Work"]
+    },
+    "MECH": {
+        "1": ["Mathematics-I", "Engineering Physics", "Engineering Mechanics", "Engineering Graphics", "Workshop Practice"],
+        "2": ["Thermodynamics", "Fluid Mechanics", "Strength of Materials", "Manufacturing Processes", "Machine Drawing"],
+        "3": ["Heat Transfer", "Dynamics of Machines", "Machine Design", "Industrial Engineering", "CAD/CAM"],
+        "4": ["Automobile Engineering", "Robotics", "Finite Element Analysis", "Refrigeration & Air Conditioning", "Project Work"]
+    },
+    "EEE": {
+        "1": ["Mathematics-I", "Engineering Chemistry", "Basic Electrical Engineering", "Engineering Graphics", "English Communication"],
+        "2": ["Circuit Theory", "Electromagnetic Fields", "Analog Electronics", "Digital Electronics", "Signals and Systems"],
+        "3": ["Power Systems", "Control Systems", "Electrical Machines", "Power Electronics", "Microprocessors"],
+        "4": ["High Voltage Engineering", "Renewable Energy Systems", "Electrical Drives", "Smart Grid", "Project Work"]
+    },
+    "CIVIL": {
+        "1": ["Mathematics-I", "Engineering Physics", "Engineering Mechanics", "Engineering Graphics", "Environmental Science"],
+        "2": ["Strength of Materials", "Fluid Mechanics", "Surveying", "Building Materials", "Engineering Geology"],
+        "3": ["Structural Analysis", "Geotechnical Engineering", "Transportation Engineering", "Water Resources Engineering", "Concrete Technology"],
+        "4": ["Environmental Engineering", "Design of Structures", "Construction Management", "Remote Sensing", "Project Work"]
+    }
+}
+
+# Example of known PDF sources for some subjects (optional)
+sample_sources = {
+    # 'Operating Systems': 'https://example.com/os_sample.pdf'
+}
+
+def fetch_pdf(url):
+    try:
+        r = requests.get(url, timeout=15)
+        if r.status_code == 200 and 'application/pdf' in r.headers.get('Content-Type', ''):
+            return r.content
+    except Exception:
+        pass
+    return None
+
+class DummyPDF(FPDF):
+    def header(self):
+        self.set_font('Arial', 'B', 14)
+        self.cell(0, 10, self.title, ln=True, align='C')
+        self.ln(10)
+
+def generate_dummy_pdf(path, subject, branch, year, paper_type):
+    pdf = DummyPDF()
+    pdf.title = f"{subject} - {paper_type}"
+    pdf.add_page()
+    pdf.set_font('Arial', size=12)
+    pdf.multi_cell(0, 10, f"Branch: {branch}\nYear: {year}\nThis is a placeholder question paper for {subject} ({paper_type}).")
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    pdf.output(path)
+
+
+def ensure_lfs_tracking():
+    attribute_line = 'sample_papers/** filter=lfs diff=lfs merge=lfs -text\n'
+    if os.path.exists('.gitattributes'):
+        with open('.gitattributes', 'r+') as f:
+            content = f.read()
+            if 'sample_papers/**' not in content:
+                if not content.endswith('\n'):
+                    f.write('\n')
+                f.write(attribute_line)
+    else:
+        with open('.gitattributes', 'w') as f:
+            f.write(attribute_line)
+
+
+def main():
+    ensure_lfs_tracking()
+    repo = Repo('.')
+    paper_types = {
+        'mid': 'Mid Semester',
+        'final': 'Final Exam',
+        'quiz': 'Quiz',
+        'mock': 'Mock Test'
+    }
+    tasks = []
+    for branch, years in subjectsDatabase.items():
+        for year, subjects in years.items():
+            for pkey in paper_types.keys():
+                for subject in subjects:
+                    filename = subject.replace(' ', '_') + '.pdf'
+                    path = os.path.join('sample_papers', branch, year, pkey, filename)
+                    tasks.append((subject, branch, year, pkey, paper_types[pkey], path))
+
+    for subject, branch, year, key, label, path in tqdm(tasks, desc='Processing'):
+        if os.path.exists(path):
+            continue
+        content = None
+        if subject in sample_sources:
+            content = fetch_pdf(sample_sources[subject])
+        if content:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, 'wb') as f:
+                f.write(content)
+        else:
+            generate_dummy_pdf(path, subject, branch, year, label)
+
+    repo.git.add('sample_papers')
+    repo.git.add('.gitattributes')
+    if repo.is_dirty():
+        repo.index.commit('Add generated sample question papers')
+
+if __name__ == '__main__':
+    main()

--- a/sample_papers/CIVIL/1/final/Engineering_Graphics.pdf
+++ b/sample_papers/CIVIL/1/final/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d9540a3dcb8bf2c40bccc9400bdb9cc9db3ee9dbbe7c64438f52c0b93e770e8
+size 1257

--- a/sample_papers/CIVIL/1/final/Engineering_Mechanics.pdf
+++ b/sample_papers/CIVIL/1/final/Engineering_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0453638839046261ce5b4a861cce66330f63a747305019c1c7ab7076080d0764
+size 1261

--- a/sample_papers/CIVIL/1/final/Engineering_Physics.pdf
+++ b/sample_papers/CIVIL/1/final/Engineering_Physics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0269ce99a49c56cf1f4281866490060c3a3b4d3cc002e60ba3e506729d07efb
+size 1263

--- a/sample_papers/CIVIL/1/final/Environmental_Science.pdf
+++ b/sample_papers/CIVIL/1/final/Environmental_Science.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfe106d927d8188f8dd1711e3516718324441ecbb4f9945297ec05bfab156c03
+size 1263

--- a/sample_papers/CIVIL/1/final/Mathematics-I.pdf
+++ b/sample_papers/CIVIL/1/final/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8038f1dab4d5772741ea52420df6b72844fe694e82aebb8bc50779aeb0b4e0b
+size 1244

--- a/sample_papers/CIVIL/1/mid/Engineering_Graphics.pdf
+++ b/sample_papers/CIVIL/1/mid/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e1562f1c192ebc4c56779a51cfcdc2e04b9a75cbf495fdf506fc0ede048dbb2
+size 1261

--- a/sample_papers/CIVIL/1/mid/Engineering_Mechanics.pdf
+++ b/sample_papers/CIVIL/1/mid/Engineering_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df6c8e1c91eaca3ae2d35aa7e908c3ff1debf4af68bedd0d6b4f8aeb979fb9ef
+size 1266

--- a/sample_papers/CIVIL/1/mid/Engineering_Physics.pdf
+++ b/sample_papers/CIVIL/1/mid/Engineering_Physics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a642221f4722264987fd43a56fe16f58e63bbc430d4a0262b2048b4170bf934
+size 1261

--- a/sample_papers/CIVIL/1/mid/Environmental_Science.pdf
+++ b/sample_papers/CIVIL/1/mid/Environmental_Science.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd81679c81cca0c5a13895d4e82a18c598300b63dc64df6f8698ad0c64e6db79
+size 1268

--- a/sample_papers/CIVIL/1/mid/Mathematics-I.pdf
+++ b/sample_papers/CIVIL/1/mid/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee0bb8b6290a1cedcfbaff47ef839606e9c9c374534f5dcba84f70706b54bbac
+size 1248

--- a/sample_papers/CIVIL/1/mock/Engineering_Graphics.pdf
+++ b/sample_papers/CIVIL/1/mock/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b3d8773de432114769701e78a3cf3e33bafe8285c3094d6a2cbec7f699fc36d
+size 1256

--- a/sample_papers/CIVIL/1/mock/Engineering_Mechanics.pdf
+++ b/sample_papers/CIVIL/1/mock/Engineering_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b20dbba2b3f56e43dca1dd63fa77866d780cf758b858a72f53138982290b2a47
+size 1257

--- a/sample_papers/CIVIL/1/mock/Engineering_Physics.pdf
+++ b/sample_papers/CIVIL/1/mock/Engineering_Physics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88aa97752bc4868eb07bfa43a31a54fa8e65b02ffee443d7beee079c0fa2c2d0
+size 1260

--- a/sample_papers/CIVIL/1/mock/Environmental_Science.pdf
+++ b/sample_papers/CIVIL/1/mock/Environmental_Science.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:daf4dfd0c3f8bb2b2e03a84a526cc104771d7d4ae27607f8d6b337cb3ff5b774
+size 1263

--- a/sample_papers/CIVIL/1/mock/Mathematics-I.pdf
+++ b/sample_papers/CIVIL/1/mock/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a25719ccecd0421b3bc631104ac7a28cdded1481b3e8b406d280f66e074c266
+size 1242

--- a/sample_papers/CIVIL/1/quiz/Engineering_Graphics.pdf
+++ b/sample_papers/CIVIL/1/quiz/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78c7e40e98b48ccc89c9e52300025ca0bcbad033f0193111fb01ab23481cfd56
+size 1247

--- a/sample_papers/CIVIL/1/quiz/Engineering_Mechanics.pdf
+++ b/sample_papers/CIVIL/1/quiz/Engineering_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c83f131fba0c2cce9ec0f8d5ab96f1f9297d5d69def103374d67d12e5fc8f852
+size 1249

--- a/sample_papers/CIVIL/1/quiz/Engineering_Physics.pdf
+++ b/sample_papers/CIVIL/1/quiz/Engineering_Physics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61fd1cade11d3f0ab3df8a15e2afc6202a76333e6859d62f899e1b2f06485da8
+size 1247

--- a/sample_papers/CIVIL/1/quiz/Environmental_Science.pdf
+++ b/sample_papers/CIVIL/1/quiz/Environmental_Science.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e4f98b0f9b17d077bf82408c739222932e8cb88ed5b9fb7f9aa86f983791aeb
+size 1249

--- a/sample_papers/CIVIL/1/quiz/Mathematics-I.pdf
+++ b/sample_papers/CIVIL/1/quiz/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b19ff9d31e6be0987bad5d61eb13c0a2dffee878274b0165cb2031cc63dd43f
+size 1236

--- a/sample_papers/CIVIL/2/final/Building_Materials.pdf
+++ b/sample_papers/CIVIL/2/final/Building_Materials.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e5878c70d9b7b26157c151c100f49b805ab272e5bd7536e7e4194b164b12640
+size 1253

--- a/sample_papers/CIVIL/2/final/Engineering_Geology.pdf
+++ b/sample_papers/CIVIL/2/final/Engineering_Geology.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:908dbf1777bc1fa494886546c1d09eddcad5c837c77d35ac2dc96fcf8e45f83d
+size 1256

--- a/sample_papers/CIVIL/2/final/Fluid_Mechanics.pdf
+++ b/sample_papers/CIVIL/2/final/Fluid_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d68360f2fe9f989b7c9b932543ab0016240b08d4d9a590b9b6a0ae0f4bfd993
+size 1246

--- a/sample_papers/CIVIL/2/final/Strength_of_Materials.pdf
+++ b/sample_papers/CIVIL/2/final/Strength_of_Materials.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:942d2d51a6c87a70326f5cfe99e2e1977a5b04080e1867c72529c32095f49b8b
+size 1264

--- a/sample_papers/CIVIL/2/final/Surveying.pdf
+++ b/sample_papers/CIVIL/2/final/Surveying.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c0e8c14b68843082a1f5dd5c2cbeafb6041bfcfbcc2cf86f30c0f7fe0321bd2
+size 1238

--- a/sample_papers/CIVIL/2/mid/Building_Materials.pdf
+++ b/sample_papers/CIVIL/2/mid/Building_Materials.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8beb8ea0cf2b9be28c71158efdfc94ed6bfa4053e4bdd4e7fbd5e0edd8ff464
+size 1257

--- a/sample_papers/CIVIL/2/mid/Engineering_Geology.pdf
+++ b/sample_papers/CIVIL/2/mid/Engineering_Geology.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:186c92105f73dab7890bf1bde34e0ca78bd6790a5cd5dfdb436a6396e0d1b748
+size 1265

--- a/sample_papers/CIVIL/2/mid/Fluid_Mechanics.pdf
+++ b/sample_papers/CIVIL/2/mid/Fluid_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:923dc0424a903be93ff214832aadc36275ce8fab71e41197cfd62977d783fb49
+size 1252

--- a/sample_papers/CIVIL/2/mid/Strength_of_Materials.pdf
+++ b/sample_papers/CIVIL/2/mid/Strength_of_Materials.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cfe0bee28e5abd17cfc0b0cc44a39b30016ffac8621bfdb1dad5dcf4eacaa62
+size 1263

--- a/sample_papers/CIVIL/2/mid/Surveying.pdf
+++ b/sample_papers/CIVIL/2/mid/Surveying.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea5d49a0f85c826c421bb2ab312b0b3de49544b49e53d000df8b3acb2ab19c88
+size 1242

--- a/sample_papers/CIVIL/2/mock/Building_Materials.pdf
+++ b/sample_papers/CIVIL/2/mock/Building_Materials.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fdf446cb585cb9c85992ce1d80e55e9f39b82ed0801cb2b24e10df6f2ef5d2b
+size 1251

--- a/sample_papers/CIVIL/2/mock/Engineering_Geology.pdf
+++ b/sample_papers/CIVIL/2/mock/Engineering_Geology.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07e711f9a0435f60473db9e9903bb4cd22b8e0e00c92c83cb8ba403a3a780abb
+size 1256

--- a/sample_papers/CIVIL/2/mock/Fluid_Mechanics.pdf
+++ b/sample_papers/CIVIL/2/mock/Fluid_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57e8b7c0bd52d97cd5fb71cd56f6234ea625457343411efb8f692e5926de0ed6
+size 1245

--- a/sample_papers/CIVIL/2/mock/Strength_of_Materials.pdf
+++ b/sample_papers/CIVIL/2/mock/Strength_of_Materials.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:895c3ddc2c9e67ff8266dc1f49011ba17afc105b55654cf20fe41536b4f4f695
+size 1258

--- a/sample_papers/CIVIL/2/mock/Surveying.pdf
+++ b/sample_papers/CIVIL/2/mock/Surveying.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e5b8631c84520280a2fc71e882b341d3ba62dbf6001a7b5c417b2e4f3b88a07
+size 1237

--- a/sample_papers/CIVIL/2/quiz/Building_Materials.pdf
+++ b/sample_papers/CIVIL/2/quiz/Building_Materials.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8caf3acccdda64a429f48fcf34759356dbc53ef7e76e9dbbf8f9da3677df541
+size 1244

--- a/sample_papers/CIVIL/2/quiz/Engineering_Geology.pdf
+++ b/sample_papers/CIVIL/2/quiz/Engineering_Geology.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef343f04446311ed7f1ecbe7e3ed6cc539410a2b5531943387014b7371845da0
+size 1246

--- a/sample_papers/CIVIL/2/quiz/Fluid_Mechanics.pdf
+++ b/sample_papers/CIVIL/2/quiz/Fluid_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:327640db385ad5ae5ebee3bf58bb366d3cae91f9bb095ed114be492409d0d5ed
+size 1239

--- a/sample_papers/CIVIL/2/quiz/Strength_of_Materials.pdf
+++ b/sample_papers/CIVIL/2/quiz/Strength_of_Materials.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3064fdf95a0a55435cb4e11af67f732828f866d5a333795d9538dddbaa7bff43
+size 1250

--- a/sample_papers/CIVIL/2/quiz/Surveying.pdf
+++ b/sample_papers/CIVIL/2/quiz/Surveying.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88f8480332493226dbab6a12db9a671ad64cc16e91689f77c23869e60b968d20
+size 1228

--- a/sample_papers/CIVIL/3/final/Concrete_Technology.pdf
+++ b/sample_papers/CIVIL/3/final/Concrete_Technology.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f99f06acb18759786cf95ef876ca185e122541c40e5a98d721176324b624150
+size 1258

--- a/sample_papers/CIVIL/3/final/Geotechnical_Engineering.pdf
+++ b/sample_papers/CIVIL/3/final/Geotechnical_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb9dc55b509d9ab18b48c183ec5384baea15e19d4e39e2c779650d8fe2fdb882
+size 1263

--- a/sample_papers/CIVIL/3/final/Structural_Analysis.pdf
+++ b/sample_papers/CIVIL/3/final/Structural_Analysis.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e505e78dbaa9f8b2629b9811bb4daa9007e27d6bc7de765dd3a3340c7b567ad5
+size 1259

--- a/sample_papers/CIVIL/3/final/Transportation_Engineering.pdf
+++ b/sample_papers/CIVIL/3/final/Transportation_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba47035ee76b2cbdc074c5a2806466433cd67793ba6f81971bc9ad685b9194cc
+size 1267

--- a/sample_papers/CIVIL/3/final/Water_Resources_Engineering.pdf
+++ b/sample_papers/CIVIL/3/final/Water_Resources_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5877d7e528cbb148b12bc88b8afbfa56e0e9871a1071c2f9aa854052c01a931b
+size 1276

--- a/sample_papers/CIVIL/3/mid/Concrete_Technology.pdf
+++ b/sample_papers/CIVIL/3/mid/Concrete_Technology.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee33b115481eab1224e557411f873116a95f0ac5c4a96f6826d9f38005e9e532
+size 1261

--- a/sample_papers/CIVIL/3/mid/Geotechnical_Engineering.pdf
+++ b/sample_papers/CIVIL/3/mid/Geotechnical_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf02808f25e52daedb766e394608af884fc5c532d5f918dc54303ad9c2033665
+size 1271

--- a/sample_papers/CIVIL/3/mid/Structural_Analysis.pdf
+++ b/sample_papers/CIVIL/3/mid/Structural_Analysis.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ee3f838590b44bb65e235e4b0ab34036d81d04f8c3c759cef117be31e94da7b
+size 1261

--- a/sample_papers/CIVIL/3/mid/Transportation_Engineering.pdf
+++ b/sample_papers/CIVIL/3/mid/Transportation_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:096ff13fc48307c15687fb2ccedcee561b89fc4cc5cfdf71998d375817edbf55
+size 1271

--- a/sample_papers/CIVIL/3/mid/Water_Resources_Engineering.pdf
+++ b/sample_papers/CIVIL/3/mid/Water_Resources_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dab24c5c434d9b20112090cf722028250457188812bf80ab4d5e59f269c8b4e
+size 1277

--- a/sample_papers/CIVIL/3/mock/Concrete_Technology.pdf
+++ b/sample_papers/CIVIL/3/mock/Concrete_Technology.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f51949f42ea05c4104e024950155479fea36d6e8a0339ccc8df9ee803deaeee
+size 1254

--- a/sample_papers/CIVIL/3/mock/Geotechnical_Engineering.pdf
+++ b/sample_papers/CIVIL/3/mock/Geotechnical_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aab4bf3caa392b18c1faffef112772864de3d30a83e493b6ef8e94f26c11d046
+size 1262

--- a/sample_papers/CIVIL/3/mock/Structural_Analysis.pdf
+++ b/sample_papers/CIVIL/3/mock/Structural_Analysis.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e290763cf910b6e1bcaf5d1e5818399328f79705668392804f0db8cd234b5a7
+size 1257

--- a/sample_papers/CIVIL/3/mock/Transportation_Engineering.pdf
+++ b/sample_papers/CIVIL/3/mock/Transportation_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57edf69587b887f91305f32dc78badb91f7384efa1d99c89b50643ae28437322
+size 1266

--- a/sample_papers/CIVIL/3/mock/Water_Resources_Engineering.pdf
+++ b/sample_papers/CIVIL/3/mock/Water_Resources_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f7a2b30d06dc017bff1930578b16b3e455fbd090ba28128cdd24f582bd633c9
+size 1270

--- a/sample_papers/CIVIL/3/quiz/Concrete_Technology.pdf
+++ b/sample_papers/CIVIL/3/quiz/Concrete_Technology.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbb9861a80c826f7db0c9ff47fd81f1ec1e96e916ac3a375660684f687c0cd85
+size 1246

--- a/sample_papers/CIVIL/3/quiz/Geotechnical_Engineering.pdf
+++ b/sample_papers/CIVIL/3/quiz/Geotechnical_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73b8c30ed250e190bea3fe9d942d4c9ad606aba7f7bc7df6d6698c72c72595f4
+size 1257

--- a/sample_papers/CIVIL/3/quiz/Structural_Analysis.pdf
+++ b/sample_papers/CIVIL/3/quiz/Structural_Analysis.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7054d74f6cdf0a29670561a2f63ba44a994ce940662a996b2ae8c62af8d3dc8a
+size 1247

--- a/sample_papers/CIVIL/3/quiz/Transportation_Engineering.pdf
+++ b/sample_papers/CIVIL/3/quiz/Transportation_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9af892bc781fd78255c9bce00aa3807fcde6da46815135e4a36920415f3bda6
+size 1259

--- a/sample_papers/CIVIL/3/quiz/Water_Resources_Engineering.pdf
+++ b/sample_papers/CIVIL/3/quiz/Water_Resources_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e62f6d6b6c73508408060a60d46bc8ee35d2d650feee8fde47827d50766697c
+size 1263

--- a/sample_papers/CIVIL/4/final/Construction_Management.pdf
+++ b/sample_papers/CIVIL/4/final/Construction_Management.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23a98fce456e733626ebb8a26a315f9cb6649a8f4dc04dbf0a9d6a2fa45490f9
+size 1263

--- a/sample_papers/CIVIL/4/final/Design_of_Structures.pdf
+++ b/sample_papers/CIVIL/4/final/Design_of_Structures.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e630f7755d92b1560446803633e91f24a955586af675c1fe1e846d0ce0dafa48
+size 1259

--- a/sample_papers/CIVIL/4/final/Environmental_Engineering.pdf
+++ b/sample_papers/CIVIL/4/final/Environmental_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2509e9f518ff531f9eaec23abc16d2262be25ba70ce19842fcfdfd0417e83b87
+size 1265

--- a/sample_papers/CIVIL/4/final/Project_Work.pdf
+++ b/sample_papers/CIVIL/4/final/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32cf60d5b0cf726dfedf93af7f0a3929849f35fcca56528fe30af21cca846d67
+size 1243

--- a/sample_papers/CIVIL/4/final/Remote_Sensing.pdf
+++ b/sample_papers/CIVIL/4/final/Remote_Sensing.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e5d8d47781e7fcdc3ffc833f0a9cabff4e47595f43de4da73603530c5c3b008
+size 1247

--- a/sample_papers/CIVIL/4/mid/Construction_Management.pdf
+++ b/sample_papers/CIVIL/4/mid/Construction_Management.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00edb7d4733bc65884c2e8c9b9d30ca40235b177e23b4c930899dafc61ebcd92
+size 1267

--- a/sample_papers/CIVIL/4/mid/Design_of_Structures.pdf
+++ b/sample_papers/CIVIL/4/mid/Design_of_Structures.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:178f375fb1c0145fd79921de1f3057a40b063b274a28dd8af507067a0c799b84
+size 1263

--- a/sample_papers/CIVIL/4/mid/Environmental_Engineering.pdf
+++ b/sample_papers/CIVIL/4/mid/Environmental_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:305cdb9236dc29e03052440a1d65a0103dbf3cf3940dd779b9405f97b82a73d0
+size 1275

--- a/sample_papers/CIVIL/4/mid/Project_Work.pdf
+++ b/sample_papers/CIVIL/4/mid/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c72439624e1df2ec902388f7807a15207c1055f039527a8dc5783cd1c39bd14
+size 1247

--- a/sample_papers/CIVIL/4/mid/Remote_Sensing.pdf
+++ b/sample_papers/CIVIL/4/mid/Remote_Sensing.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78d5efd038b4260299b433d3f5a27c4e4f101393abd60cd6c6e9776667a92e0a
+size 1251

--- a/sample_papers/CIVIL/4/mock/Construction_Management.pdf
+++ b/sample_papers/CIVIL/4/mock/Construction_Management.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bf4ace1768ddb6840d1cd6a78b7527298aad80fab7fa01645f74e55b848f0de
+size 1263

--- a/sample_papers/CIVIL/4/mock/Design_of_Structures.pdf
+++ b/sample_papers/CIVIL/4/mock/Design_of_Structures.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3092812fe2022586bf01b52515520c34cf70c344a715f3f1618264b1363a7fc
+size 1257

--- a/sample_papers/CIVIL/4/mock/Environmental_Engineering.pdf
+++ b/sample_papers/CIVIL/4/mock/Environmental_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dec5286650861e49be0ba528cc25cf754d00c1a2333a1aa0e33cd7b7061b8500
+size 1266

--- a/sample_papers/CIVIL/4/mock/Project_Work.pdf
+++ b/sample_papers/CIVIL/4/mock/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41b025738b4d9facb00ca1738e359943a26087e15ed6158adbb44e3f66af4320
+size 1240

--- a/sample_papers/CIVIL/4/mock/Remote_Sensing.pdf
+++ b/sample_papers/CIVIL/4/mock/Remote_Sensing.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:261bc417db8de85be27aadda303eaf97029b55773df7c4b830baf7cc8ca95ae4
+size 1246

--- a/sample_papers/CIVIL/4/quiz/Construction_Management.pdf
+++ b/sample_papers/CIVIL/4/quiz/Construction_Management.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d178fc325b057d0a1f15698dc20685f2730269f05d8db3abc461e4ca59f8d9a3
+size 1254

--- a/sample_papers/CIVIL/4/quiz/Design_of_Structures.pdf
+++ b/sample_papers/CIVIL/4/quiz/Design_of_Structures.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c08b38162b62975e559f71a9bd38ccdcdc04702a2a11cf50925b13825de4db76
+size 1249

--- a/sample_papers/CIVIL/4/quiz/Environmental_Engineering.pdf
+++ b/sample_papers/CIVIL/4/quiz/Environmental_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:512a881472e4a1155376c5c1dc075e57be0b60a8fce5d91f54a25d36d778cb96
+size 1257

--- a/sample_papers/CIVIL/4/quiz/Project_Work.pdf
+++ b/sample_papers/CIVIL/4/quiz/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34683307c32eae9487f7ee8112a67dd8bb04b9fd9e8e3b95cfb21cd273774b90
+size 1234

--- a/sample_papers/CIVIL/4/quiz/Remote_Sensing.pdf
+++ b/sample_papers/CIVIL/4/quiz/Remote_Sensing.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0a8153fc3095a6274f5fcd0049fa01bc702521754020b0d2a29dea97c0f5700
+size 1238

--- a/sample_papers/CSE/1/final/Engineering_Graphics.pdf
+++ b/sample_papers/CSE/1/final/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4db07158246aa9abf586d8bc6971c419e7a5b343582ba896e526b8c68857992
+size 1253

--- a/sample_papers/CSE/1/final/Engineering_Physics.pdf
+++ b/sample_papers/CSE/1/final/Engineering_Physics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63bffc15b835acfdb813ea68dc1a2b2c9b54f5148b9071b46c66263bc3a2a3d7
+size 1253

--- a/sample_papers/CSE/1/final/Environmental_Science.pdf
+++ b/sample_papers/CSE/1/final/Environmental_Science.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5371b70c643c11c90dea73d0dff97320e74eefe246c8e9db474f22c701a47d78
+size 1256

--- a/sample_papers/CSE/1/final/Mathematics-I.pdf
+++ b/sample_papers/CSE/1/final/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed67d0854ec10415f02b4b359dc10d290ce3a25adf3d66af537c59a9da94bf25
+size 1242

--- a/sample_papers/CSE/1/final/Programming_Fundamentals.pdf
+++ b/sample_papers/CSE/1/final/Programming_Fundamentals.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1365b9636925c21e7bf77ccc76202b6c1a790ea91e5fe10767ca3285b677cbb
+size 1266

--- a/sample_papers/CSE/1/mid/Engineering_Graphics.pdf
+++ b/sample_papers/CSE/1/mid/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fd511f8883a292935bb199a89006cdd4e73a330579489141838fed34a05adb2
+size 1259

--- a/sample_papers/CSE/1/mid/Engineering_Physics.pdf
+++ b/sample_papers/CSE/1/mid/Engineering_Physics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d24f979aa83c43b19c93aa464f4b3887242385f79c11aac95db85a9ca60ef39d
+size 1259

--- a/sample_papers/CSE/1/mid/Environmental_Science.pdf
+++ b/sample_papers/CSE/1/mid/Environmental_Science.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6f03065e6813bce0555ae3e672df2e5352a684a8adb53e65cad103d80db03d3
+size 1264

--- a/sample_papers/CSE/1/mid/Mathematics-I.pdf
+++ b/sample_papers/CSE/1/mid/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c538d3bbba26fd93c27af3207e4159572d99cba05ea1eac8b9c29a4ef9821d21
+size 1245

--- a/sample_papers/CSE/1/mid/Programming_Fundamentals.pdf
+++ b/sample_papers/CSE/1/mid/Programming_Fundamentals.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfc10dfef0dbdbd7f1a71d0a49f1cc69757577dc624c5dcc163f5bbb242e0c56
+size 1267

--- a/sample_papers/CSE/1/mock/Engineering_Graphics.pdf
+++ b/sample_papers/CSE/1/mock/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e2ba1b4c74e7f869f0a3819cdd787c07f807ccf530619be1651d0e339f30c80
+size 1253

--- a/sample_papers/CSE/1/mock/Engineering_Physics.pdf
+++ b/sample_papers/CSE/1/mock/Engineering_Physics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2c39a0a56260d0f5873777ab107826e130b58edbf1600c3f94ac3e9a048cdbc
+size 1253

--- a/sample_papers/CSE/1/mock/Environmental_Science.pdf
+++ b/sample_papers/CSE/1/mock/Environmental_Science.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bb12a564912b583d9d65512989176a77e3350b4b5c5ffaf6a3bd75ad1dae55d
+size 1254

--- a/sample_papers/CSE/1/mock/Mathematics-I.pdf
+++ b/sample_papers/CSE/1/mock/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:759a339d1bbe1be0dc0d4725330e101c5a147298e4e27256f15eb45a2358007e
+size 1240

--- a/sample_papers/CSE/1/mock/Programming_Fundamentals.pdf
+++ b/sample_papers/CSE/1/mock/Programming_Fundamentals.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a13bd34f4d678f66d127b15fb517243265f7d9a73df7f758787f72172c12abc9
+size 1266

--- a/sample_papers/CSE/1/quiz/Engineering_Graphics.pdf
+++ b/sample_papers/CSE/1/quiz/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80cc2a13a39d34885a48352f32bd3a2f6b69e31491163b446d64906a85059fe3
+size 1245

--- a/sample_papers/CSE/1/quiz/Engineering_Physics.pdf
+++ b/sample_papers/CSE/1/quiz/Engineering_Physics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4639e91a3798d01ee779ce10cd2b0d44c249d0981502898ed7fe10f2b5198d1b
+size 1243

--- a/sample_papers/CSE/1/quiz/Environmental_Science.pdf
+++ b/sample_papers/CSE/1/quiz/Environmental_Science.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03221e45aca036b2007485ae655ff450ffc5a3001a50fcbd8c6ac79956e25c97
+size 1247

--- a/sample_papers/CSE/1/quiz/Mathematics-I.pdf
+++ b/sample_papers/CSE/1/quiz/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7476d68fb9e0e43a71f2ebe244ad077d30ba46d87d7ed7fc7f74299d98fa143b
+size 1234

--- a/sample_papers/CSE/1/quiz/Programming_Fundamentals.pdf
+++ b/sample_papers/CSE/1/quiz/Programming_Fundamentals.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a27e7d3698a104683326343c2d084181e237320816f93efc4140c517627bf5a1
+size 1253

--- a/sample_papers/CSE/2/final/Data_Structures_&_Algorithms.pdf
+++ b/sample_papers/CSE/2/final/Data_Structures_&_Algorithms.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c6b0c62407fb0377a32a76334c18c59868d906c61fc057305831f4cf654e64b
+size 1274

--- a/sample_papers/CSE/2/final/Database_Management_Systems.pdf
+++ b/sample_papers/CSE/2/final/Database_Management_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75b923975aae81342e4516fdf3642f98a34e7b7b5869dff75852bfa1337fffc7
+size 1272

--- a/sample_papers/CSE/2/final/Digital_Logic_Design.pdf
+++ b/sample_papers/CSE/2/final/Digital_Logic_Design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f2b8b502abcf7552046963f303cfd32cf061c21cf6dfa9b6bf5fb51c0bee36d
+size 1256

--- a/sample_papers/CSE/2/final/Discrete_Mathematics.pdf
+++ b/sample_papers/CSE/2/final/Discrete_Mathematics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab202b84c6e30184612bdb588a03aac34fc61a8b7f36be5815a93d18eaed7690
+size 1256

--- a/sample_papers/CSE/2/final/Object_Oriented_Programming.pdf
+++ b/sample_papers/CSE/2/final/Object_Oriented_Programming.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3a537968b89899e9ef64fc8a6f466f7844f0230baadbaf759ace1e241f95c39
+size 1270

--- a/sample_papers/CSE/2/mid/Data_Structures_&_Algorithms.pdf
+++ b/sample_papers/CSE/2/mid/Data_Structures_&_Algorithms.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a8e313d0c6683d56d2874e63aa0c3d4ebfb51f998de487705359d5accb5dd45
+size 1275

--- a/sample_papers/CSE/2/mid/Database_Management_Systems.pdf
+++ b/sample_papers/CSE/2/mid/Database_Management_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9e5fbf10189fd792f5c4bd2fff87b6ed83b17c8728e5c75d5123a44863675a9
+size 1271

--- a/sample_papers/CSE/2/mid/Digital_Logic_Design.pdf
+++ b/sample_papers/CSE/2/mid/Digital_Logic_Design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32dcdd11325f9827aa5878bda19b96edb4e101d2abf26935cb5c03f3e4795772
+size 1260

--- a/sample_papers/CSE/2/mid/Discrete_Mathematics.pdf
+++ b/sample_papers/CSE/2/mid/Discrete_Mathematics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f14eb61ddbcf3aa166baa0d2f635014465752215257b6769c6f7775715926064
+size 1259

--- a/sample_papers/CSE/2/mid/Object_Oriented_Programming.pdf
+++ b/sample_papers/CSE/2/mid/Object_Oriented_Programming.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:405b225e6d74e851bf5df0ae5915a9a57b4dac1d108508cc24558344a2f5c5ae
+size 1273

--- a/sample_papers/CSE/2/mock/Data_Structures_&_Algorithms.pdf
+++ b/sample_papers/CSE/2/mock/Data_Structures_&_Algorithms.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1f2c75c2738e292e91e0cdc0ac6ae963c165048ebca9a5875d4dc1f16a61410
+size 1270

--- a/sample_papers/CSE/2/mock/Database_Management_Systems.pdf
+++ b/sample_papers/CSE/2/mock/Database_Management_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12d6e444af010fadb1450765da00e46b0ed199078afb0f220909c5cb7b288b56
+size 1268

--- a/sample_papers/CSE/2/mock/Digital_Logic_Design.pdf
+++ b/sample_papers/CSE/2/mock/Digital_Logic_Design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6eb8e4a41b240036b66c1e5054cd4c4b89b9e05a8c27f9fdd06cc2c6e4ab695b
+size 1254

--- a/sample_papers/CSE/2/mock/Discrete_Mathematics.pdf
+++ b/sample_papers/CSE/2/mock/Discrete_Mathematics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0062c403c4d92f6c33cd3e395813322345399471979f7b146a2659e794f31ad8
+size 1254

--- a/sample_papers/CSE/2/mock/Object_Oriented_Programming.pdf
+++ b/sample_papers/CSE/2/mock/Object_Oriented_Programming.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6121c61102f2256552ba4066a7cc0ac43550b7089e6a46a4441df667c7ed682b
+size 1269

--- a/sample_papers/CSE/2/quiz/Data_Structures_&_Algorithms.pdf
+++ b/sample_papers/CSE/2/quiz/Data_Structures_&_Algorithms.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d077dea0880e7ead2d413627cadf605c99cc24cdb0c24340fb891f23cdfa05f8
+size 1261

--- a/sample_papers/CSE/2/quiz/Database_Management_Systems.pdf
+++ b/sample_papers/CSE/2/quiz/Database_Management_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cca911ea9ebe239816f08297c9891b1a2f88b0d3b02b3ef838bc3c08435147d
+size 1261

--- a/sample_papers/CSE/2/quiz/Digital_Logic_Design.pdf
+++ b/sample_papers/CSE/2/quiz/Digital_Logic_Design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfc6df2912d8b2a77ebd9c44c5144514f844a50ff03c2c3b31dfa3cde0552d36
+size 1246

--- a/sample_papers/CSE/2/quiz/Discrete_Mathematics.pdf
+++ b/sample_papers/CSE/2/quiz/Discrete_Mathematics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:099f3ea6bec01588c7269b403e1ea78fcb9ce9b2ac0495ed423a134dd6e8d81b
+size 1246

--- a/sample_papers/CSE/2/quiz/Object_Oriented_Programming.pdf
+++ b/sample_papers/CSE/2/quiz/Object_Oriented_Programming.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35d9380ef7421ef1e011bf27972ef6a737e0fd99181f900d0b3720a4fec83112
+size 1260

--- a/sample_papers/CSE/3/final/Computer_Networks.pdf
+++ b/sample_papers/CSE/3/final/Computer_Networks.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80972c3161c164f827e37f7587b5c1ab6a68a68a824c272c3fe9e82a52e49494
+size 1250

--- a/sample_papers/CSE/3/final/Machine_Learning.pdf
+++ b/sample_papers/CSE/3/final/Machine_Learning.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89bc9303e7c94c8318c9aa0272c948735cbf6badd90567030ef2d55099a7acd8
+size 1247

--- a/sample_papers/CSE/3/final/Operating_Systems.pdf
+++ b/sample_papers/CSE/3/final/Operating_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb5ebc58d7ec5c46423a2e1f521dc51087213379907617a622249c6fef36f467
+size 1249

--- a/sample_papers/CSE/3/final/Software_Engineering.pdf
+++ b/sample_papers/CSE/3/final/Software_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dad15f40219b942798a3ca4f11ad50185d1c2afd1342d0d2832707a1ab2f53da
+size 1254

--- a/sample_papers/CSE/3/final/Theory_of_Computation.pdf
+++ b/sample_papers/CSE/3/final/Theory_of_Computation.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcb2ecabbcc5ba56f2f77ec943848a85a51d311991fee6cfe1e8eb81e84be947
+size 1254

--- a/sample_papers/CSE/3/final/Web_Technologies.pdf
+++ b/sample_papers/CSE/3/final/Web_Technologies.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9b02d899345ef5ecb08a795eddb739747454c169b90a207188ba842141db117
+size 1247

--- a/sample_papers/CSE/3/mid/Computer_Networks.pdf
+++ b/sample_papers/CSE/3/mid/Computer_Networks.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c116b9643c705b5d193898858b964089b85f092cff6dfe186d71211d2cd89d07
+size 1253

--- a/sample_papers/CSE/3/mid/Machine_Learning.pdf
+++ b/sample_papers/CSE/3/mid/Machine_Learning.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78d8d7094e09b8a76e6230367cbe55b2dd78253b24df1e31b55561b7ffc7a55c
+size 1250

--- a/sample_papers/CSE/3/mid/Operating_Systems.pdf
+++ b/sample_papers/CSE/3/mid/Operating_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9aacfde190a60377330176d14dd896872c289a1ff28c033b1cffec762970850
+size 1254

--- a/sample_papers/CSE/3/mid/Software_Engineering.pdf
+++ b/sample_papers/CSE/3/mid/Software_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3010c4403afb0176b99bb4b1f7b163e2adc6bf83615ed600b725a5b8397e79c
+size 1259

--- a/sample_papers/CSE/3/mid/Theory_of_Computation.pdf
+++ b/sample_papers/CSE/3/mid/Theory_of_Computation.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:275b3dc274cc2ea5f8a854e25d3e6998f506dd636b304dbd148629906ce4b08c
+size 1260

--- a/sample_papers/CSE/3/mid/Web_Technologies.pdf
+++ b/sample_papers/CSE/3/mid/Web_Technologies.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f9d90a15969b109c2c1b2858671f9a7c47377274480a7de402b10d7485268b1
+size 1251

--- a/sample_papers/CSE/3/mock/Computer_Networks.pdf
+++ b/sample_papers/CSE/3/mock/Computer_Networks.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7782d6c645f3033c874248ea89dec23308b59a8c235577b821a6ec3d04a19b82
+size 1248

--- a/sample_papers/CSE/3/mock/Machine_Learning.pdf
+++ b/sample_papers/CSE/3/mock/Machine_Learning.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54cfc2374d6c92c64c59a500f1fe645580d62ba46a05b7569290674af16c1782
+size 1244

--- a/sample_papers/CSE/3/mock/Operating_Systems.pdf
+++ b/sample_papers/CSE/3/mock/Operating_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4a5711abd951998e7b188207e1c215fae735ad9a71b378ea6b420225297ba86
+size 1248

--- a/sample_papers/CSE/3/mock/Software_Engineering.pdf
+++ b/sample_papers/CSE/3/mock/Software_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f11b112caec193da49069ad83b53cd23c8b05e3683160bfe6696275d0a62e882
+size 1253

--- a/sample_papers/CSE/3/mock/Theory_of_Computation.pdf
+++ b/sample_papers/CSE/3/mock/Theory_of_Computation.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3cf5aa025e2e7698942d2777e38ca325da1c647d42ab200230e32936464c3d7d
+size 1253

--- a/sample_papers/CSE/3/mock/Web_Technologies.pdf
+++ b/sample_papers/CSE/3/mock/Web_Technologies.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f30faebf4c641475ed0130f165fed22a1b1cda0c16870993009c14476633425
+size 1246

--- a/sample_papers/CSE/3/quiz/Computer_Networks.pdf
+++ b/sample_papers/CSE/3/quiz/Computer_Networks.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4962124b718a830038fe82b423607578f2c55f7d3f73732d1e8e2662310cce8b
+size 1241

--- a/sample_papers/CSE/3/quiz/Machine_Learning.pdf
+++ b/sample_papers/CSE/3/quiz/Machine_Learning.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a32e5407c8d26c73db59d35f845fbbd05ffa7a0e114dd377da0bab3b975b04e
+size 1238

--- a/sample_papers/CSE/3/quiz/Operating_Systems.pdf
+++ b/sample_papers/CSE/3/quiz/Operating_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9943e92e281dfa4ef6ff0cc7297ad515fb67d8ff6331be7686fae3540f1d9f40
+size 1240

--- a/sample_papers/CSE/3/quiz/Software_Engineering.pdf
+++ b/sample_papers/CSE/3/quiz/Software_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d65b04b1b4acace7791a861b38bc7d9952164aab179a402a59d2ffa847a6e47
+size 1245

--- a/sample_papers/CSE/3/quiz/Theory_of_Computation.pdf
+++ b/sample_papers/CSE/3/quiz/Theory_of_Computation.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec4cdde03abf7e416bd3774261b9ecb90b180eed491f4f36bd9795c5cef8bc14
+size 1244

--- a/sample_papers/CSE/3/quiz/Web_Technologies.pdf
+++ b/sample_papers/CSE/3/quiz/Web_Technologies.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dfd20d700b1ef6555ecb377650676f71c71655b42dba97d7f7e8aa0e30ade19
+size 1237

--- a/sample_papers/CSE/4/final/Artificial_Intelligence.pdf
+++ b/sample_papers/CSE/4/final/Artificial_Intelligence.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:690cc912aa9b8cd51e43f8b203323439a604a65c1dc51616ca1216c2601dcbe5
+size 1262

--- a/sample_papers/CSE/4/final/Big_Data_Analytics.pdf
+++ b/sample_papers/CSE/4/final/Big_Data_Analytics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf4c3cd4587b4d99bec142947699c4dcfab0b973a3eeb14cbdf6fa8a152f7516
+size 1249

--- a/sample_papers/CSE/4/final/Cloud_Computing.pdf
+++ b/sample_papers/CSE/4/final/Cloud_Computing.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e35cffd75cbf1c07d0ee143faa928db19a587a42673d11a6d3231f93570fc9e
+size 1245

--- a/sample_papers/CSE/4/final/Cybersecurity.pdf
+++ b/sample_papers/CSE/4/final/Cybersecurity.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dcf0b8223802c46a79726b4e9c2897231b195353d28acf9107573d532b106be
+size 1242

--- a/sample_papers/CSE/4/final/Internet_of_Things.pdf
+++ b/sample_papers/CSE/4/final/Internet_of_Things.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82b38e45aa2a3215276df37dca7275fa7453ca588e503d78e800c2450c0b0302
+size 1251

--- a/sample_papers/CSE/4/final/Project_Work.pdf
+++ b/sample_papers/CSE/4/final/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3fb9a4d5ab43b8abbf9e63dc41dcd50705105a55aa31a3b8453ec78d125e9ee
+size 1241

--- a/sample_papers/CSE/4/mid/Artificial_Intelligence.pdf
+++ b/sample_papers/CSE/4/mid/Artificial_Intelligence.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d47d1433408985a3d1c73aba8d4034687a9c090a2b2961f9a60c16221529655
+size 1265

--- a/sample_papers/CSE/4/mid/Big_Data_Analytics.pdf
+++ b/sample_papers/CSE/4/mid/Big_Data_Analytics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:870af20a25e2b61e857b45bb79f63f89f30fe9f6c2adc4f42701192c7e55a492
+size 1257

--- a/sample_papers/CSE/4/mid/Cloud_Computing.pdf
+++ b/sample_papers/CSE/4/mid/Cloud_Computing.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fabf454198d3c9dc5be0708090d84a0f0bed021b8866c19e3e39c06e7c3251a1
+size 1248

--- a/sample_papers/CSE/4/mid/Cybersecurity.pdf
+++ b/sample_papers/CSE/4/mid/Cybersecurity.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5be9298f2104115f471e5a71c79cd4daa1ec93ee12e715409ed67837286435a
+size 1247

--- a/sample_papers/CSE/4/mid/Internet_of_Things.pdf
+++ b/sample_papers/CSE/4/mid/Internet_of_Things.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab9b4f8c7878a24f025d20b88048006d8247acacbb492750838411fe56ccc34c
+size 1256

--- a/sample_papers/CSE/4/mid/Project_Work.pdf
+++ b/sample_papers/CSE/4/mid/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5d860ad7b6d88e68cc818fe4e746c3dbad9e15c4db3174e6dea6d3a348ff079
+size 1244

--- a/sample_papers/CSE/4/mock/Artificial_Intelligence.pdf
+++ b/sample_papers/CSE/4/mock/Artificial_Intelligence.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4499363a6c43322b3105d81ce65740dfc8d257d9c7b954e50e6fdd939ee0f90e
+size 1260

--- a/sample_papers/CSE/4/mock/Big_Data_Analytics.pdf
+++ b/sample_papers/CSE/4/mock/Big_Data_Analytics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d03ab58b9cc16ee8be15ec45326c108e27513c12d24b65a1729c11410658bb8
+size 1249

--- a/sample_papers/CSE/4/mock/Cloud_Computing.pdf
+++ b/sample_papers/CSE/4/mock/Cloud_Computing.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cea87b1543328421b64796ca04080500dd0e1b2bdd9a4e410ccd70c7893ebe82
+size 1244

--- a/sample_papers/CSE/4/mock/Cybersecurity.pdf
+++ b/sample_papers/CSE/4/mock/Cybersecurity.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8acb3daefa0684b4fb4d3303b095ac43d77afc93b0985abd5222080f811826fe
+size 1240

--- a/sample_papers/CSE/4/mock/Internet_of_Things.pdf
+++ b/sample_papers/CSE/4/mock/Internet_of_Things.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a00ce3ab72ef62b43c9dcdb17e362f99e20fcfedcf804c50f5a9ab7611f161a
+size 1250

--- a/sample_papers/CSE/4/mock/Project_Work.pdf
+++ b/sample_papers/CSE/4/mock/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eaee374d97d0790a22008c06a4481d41a69b5d821e09c2d45fa7cfe3a9b07f9c
+size 1238

--- a/sample_papers/CSE/4/quiz/Artificial_Intelligence.pdf
+++ b/sample_papers/CSE/4/quiz/Artificial_Intelligence.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28e32974126139b2c4ce29cca68b66e6f6357c5b52dd3b740c0e485dae42809b
+size 1251

--- a/sample_papers/CSE/4/quiz/Big_Data_Analytics.pdf
+++ b/sample_papers/CSE/4/quiz/Big_Data_Analytics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:928187addefcd2ff4e2b29859bbfaeefee0680cc176b21c766ebdd117e9277d7
+size 1241

--- a/sample_papers/CSE/4/quiz/Cloud_Computing.pdf
+++ b/sample_papers/CSE/4/quiz/Cloud_Computing.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6b2644674b26628031b08062aaf0894f0be6a9b41474ae9bffa12fa2013d677
+size 1236

--- a/sample_papers/CSE/4/quiz/Cybersecurity.pdf
+++ b/sample_papers/CSE/4/quiz/Cybersecurity.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cee90775e5b6b38e90e3333d2da9b54a50d27c55868db4590e89d6ed8f70a806
+size 1233

--- a/sample_papers/CSE/4/quiz/Internet_of_Things.pdf
+++ b/sample_papers/CSE/4/quiz/Internet_of_Things.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35155a392b3667c2c69d312b02098f864dff4cd74a24738d8887ff35f4e2b102
+size 1241

--- a/sample_papers/CSE/4/quiz/Project_Work.pdf
+++ b/sample_papers/CSE/4/quiz/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:420dc7826c83688f1bf5d1f3e2c921fb335e9c6023f1d26c2ec8f361885ca222
+size 1231

--- a/sample_papers/ECE/1/final/Basic_Electronics.pdf
+++ b/sample_papers/ECE/1/final/Basic_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a55125ab322429b86c5566f81ed8882176677a6968c47e397ca615d47acd9864
+size 1246

--- a/sample_papers/ECE/1/final/Engineering_Chemistry.pdf
+++ b/sample_papers/ECE/1/final/Engineering_Chemistry.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87e95397ddfef4f1710c00435bfc8df348a1bc83b2076063f2687d9d877d7d4d
+size 1254

--- a/sample_papers/ECE/1/final/Engineering_Graphics.pdf
+++ b/sample_papers/ECE/1/final/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45a0ce65c8837f54c5330e7e0a7f8f8a9f9195299ad48fde3415a7d26259fa2b
+size 1252

--- a/sample_papers/ECE/1/final/English_Communication.pdf
+++ b/sample_papers/ECE/1/final/English_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d794bf57a64798a53ce1cca4877d6cd20153bd93e4cf30d7f434756c3731d0e
+size 1254

--- a/sample_papers/ECE/1/final/Mathematics-I.pdf
+++ b/sample_papers/ECE/1/final/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15d1ed7e3bad82a80a91048b1a06f7a94a734a3ca5b93f209268630fad761b5e
+size 1242

--- a/sample_papers/ECE/1/mid/Basic_Electronics.pdf
+++ b/sample_papers/ECE/1/mid/Basic_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c147a5e6364b38f8fb6e89c54816632084e0e4a86fb31936d119a29b5c674340
+size 1251

--- a/sample_papers/ECE/1/mid/Engineering_Chemistry.pdf
+++ b/sample_papers/ECE/1/mid/Engineering_Chemistry.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:024c93c3fce3b234d2b5247790c05aecede9d341a75ef77d5747774593c7722d
+size 1264

--- a/sample_papers/ECE/1/mid/Engineering_Graphics.pdf
+++ b/sample_papers/ECE/1/mid/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cf0fe878af913a3cb21138954b3130450eeb78d5c908760976a4eedf3b6f307
+size 1259

--- a/sample_papers/ECE/1/mid/English_Communication.pdf
+++ b/sample_papers/ECE/1/mid/English_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77c30d70625eb09ebaa4ea34e744595924f23ff68929f3baf07978f4887211b6
+size 1261

--- a/sample_papers/ECE/1/mid/Mathematics-I.pdf
+++ b/sample_papers/ECE/1/mid/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34140bf552814d0f3e4eea6274af35ef29cb7e79413585436f5cfdf3ccf42623
+size 1246

--- a/sample_papers/ECE/1/mock/Basic_Electronics.pdf
+++ b/sample_papers/ECE/1/mock/Basic_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0fc70c3549ad7d5d1caf14ce2798f1844ad58def61d6fb64580617d3f2e9562
+size 1244

--- a/sample_papers/ECE/1/mock/Engineering_Chemistry.pdf
+++ b/sample_papers/ECE/1/mock/Engineering_Chemistry.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4e6633a21e3e9a35896d96a826e19c0884d04e9fb956da4a5cb0e3b0b57b9b7
+size 1257

--- a/sample_papers/ECE/1/mock/Engineering_Graphics.pdf
+++ b/sample_papers/ECE/1/mock/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bac338fee428265accfbaa8b0505393cf64a38a4e62cc88fa10ef583db5d693c
+size 1253

--- a/sample_papers/ECE/1/mock/English_Communication.pdf
+++ b/sample_papers/ECE/1/mock/English_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abaaf6942f09d8b98a78352f3f0454dab91a31a23f96190965ebfe0b7d7913a0
+size 1254

--- a/sample_papers/ECE/1/mock/Mathematics-I.pdf
+++ b/sample_papers/ECE/1/mock/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:432d362036be530cfda16d1369ff3002674645f8d176e0289998f01169e78fab
+size 1239

--- a/sample_papers/ECE/1/quiz/Basic_Electronics.pdf
+++ b/sample_papers/ECE/1/quiz/Basic_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44b22d4f653cf8db3adc7e2870c89bf3b5ed232f05582d68852d16e83e4dc8ae
+size 1237

--- a/sample_papers/ECE/1/quiz/Engineering_Chemistry.pdf
+++ b/sample_papers/ECE/1/quiz/Engineering_Chemistry.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca89ad6a1f12138f00a5233a21baf82c2503a146007fad87b2c03e841b8e1201
+size 1246

--- a/sample_papers/ECE/1/quiz/Engineering_Graphics.pdf
+++ b/sample_papers/ECE/1/quiz/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:257793af56cf53c61c619f4390f60d1ae2aaea772614a839866e1156ba6490db
+size 1244

--- a/sample_papers/ECE/1/quiz/English_Communication.pdf
+++ b/sample_papers/ECE/1/quiz/English_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ba66379bf704f9880be388bf7cdb48c97d0624f545fb8776e20e83df96724d2
+size 1246

--- a/sample_papers/ECE/1/quiz/Mathematics-I.pdf
+++ b/sample_papers/ECE/1/quiz/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a94ad10294f4eda837831c4804a5b287fcfdc563cbc17f2a9cbe32d3a31e0bb
+size 1233

--- a/sample_papers/ECE/2/final/Analog_Circuits.pdf
+++ b/sample_papers/ECE/2/final/Analog_Circuits.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63a0e6e71d79b09f27de2ed17a26790a98b15a50b173d52da62f25643b99bfe1
+size 1243

--- a/sample_papers/ECE/2/final/Digital_Electronics.pdf
+++ b/sample_papers/ECE/2/final/Digital_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7057890bc98bcc16c712a53eed47d90c34e7554751f07c99526413ee9883eba
+size 1251

--- a/sample_papers/ECE/2/final/Network_Analysis.pdf
+++ b/sample_papers/ECE/2/final/Network_Analysis.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10736977c2f861eac6da93145b8aebe47eee3abd677e1c6fa5018d8900431df9
+size 1248

--- a/sample_papers/ECE/2/final/Probability_Theory.pdf
+++ b/sample_papers/ECE/2/final/Probability_Theory.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfccd5bf3c673e6a00144ee4453ec0acb116e8485317cf6e5ca44b9a14a6252f
+size 1250

--- a/sample_papers/ECE/2/final/Signals_and_Systems.pdf
+++ b/sample_papers/ECE/2/final/Signals_and_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6077352d96021e84f36e87e2840a744d6852955a2527320b7fc0b66ae17323b5
+size 1252

--- a/sample_papers/ECE/2/mid/Analog_Circuits.pdf
+++ b/sample_papers/ECE/2/mid/Analog_Circuits.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f276fb63c2fd5144c7414978105519d31de5159cb0aa3ba2e7df098177babc96
+size 1249

--- a/sample_papers/ECE/2/mid/Digital_Electronics.pdf
+++ b/sample_papers/ECE/2/mid/Digital_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6874fc539da2a8043aac05dca9b41d80f82c4a448e4a90c85e1960a94df34b8a
+size 1258

--- a/sample_papers/ECE/2/mid/Network_Analysis.pdf
+++ b/sample_papers/ECE/2/mid/Network_Analysis.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74281b553cd46cac38ca73817d629dbe60abc86b8ada195feb3619257f8b6fdf
+size 1253

--- a/sample_papers/ECE/2/mid/Probability_Theory.pdf
+++ b/sample_papers/ECE/2/mid/Probability_Theory.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cbb5fb1b7ecf748c94e7ab2a4b5e4b7d306154116360bc00a17d5bb3d29bc0a
+size 1258

--- a/sample_papers/ECE/2/mid/Signals_and_Systems.pdf
+++ b/sample_papers/ECE/2/mid/Signals_and_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71557a126e350128e302c6fcaa7bf0bb8f07da65c8ce7ef080a8d7c913dead05
+size 1257

--- a/sample_papers/ECE/2/mock/Analog_Circuits.pdf
+++ b/sample_papers/ECE/2/mock/Analog_Circuits.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce5689011d44bc01e11c4a34521f837a1e19c3f17e1fdce0834c4b6a93853416
+size 1244

--- a/sample_papers/ECE/2/mock/Digital_Electronics.pdf
+++ b/sample_papers/ECE/2/mock/Digital_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e8f2e283ef2e27320c8ab8ceb5984bc21249c3ebae5a21fc3490bb5ca08cdfe
+size 1256

--- a/sample_papers/ECE/2/mock/Network_Analysis.pdf
+++ b/sample_papers/ECE/2/mock/Network_Analysis.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d46f1023097b0916289df27674f4da5871732c273f74af9a05536151fd41a084
+size 1247

--- a/sample_papers/ECE/2/mock/Probability_Theory.pdf
+++ b/sample_papers/ECE/2/mock/Probability_Theory.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82a363395912e2cc3c36581c1369b25a52a5e943a07fd14ee25352b6cdf10b06
+size 1250

--- a/sample_papers/ECE/2/mock/Signals_and_Systems.pdf
+++ b/sample_papers/ECE/2/mock/Signals_and_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b74de453441b5fe9e9b115c484937126aa528a7dba758a538d58ddead4c7d91
+size 1253

--- a/sample_papers/ECE/2/quiz/Analog_Circuits.pdf
+++ b/sample_papers/ECE/2/quiz/Analog_Circuits.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4eacef8a8b5ae1fc783ee90f3a8762b7a5c40fd2c99543147606bf20a6e60473
+size 1237

--- a/sample_papers/ECE/2/quiz/Digital_Electronics.pdf
+++ b/sample_papers/ECE/2/quiz/Digital_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:804343713ac18d22729e3ce92512dd1d803f7ce5cb285c3d5c4478abaa40700d
+size 1242

--- a/sample_papers/ECE/2/quiz/Network_Analysis.pdf
+++ b/sample_papers/ECE/2/quiz/Network_Analysis.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83a77f297fdfd4eb53692f42d855139ba27a1d4f295f583da77182fe19f80819
+size 1239

--- a/sample_papers/ECE/2/quiz/Probability_Theory.pdf
+++ b/sample_papers/ECE/2/quiz/Probability_Theory.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcea8ae2672747e93b9dd9ccac4a83baef1dce06970dcce87964c371e08d54c6
+size 1241

--- a/sample_papers/ECE/2/quiz/Signals_and_Systems.pdf
+++ b/sample_papers/ECE/2/quiz/Signals_and_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:956b3f979c4c3d4e70cc5abfe113a1f03796cc1c267c9a8a885eb3656eb0bc6a
+size 1244

--- a/sample_papers/ECE/3/final/Communication_Systems.pdf
+++ b/sample_papers/ECE/3/final/Communication_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18af70b4ead451f83552323f21ee65c0dd5d414322497e917038e365ecdcf0ba
+size 1256

--- a/sample_papers/ECE/3/final/Control_Systems.pdf
+++ b/sample_papers/ECE/3/final/Control_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95bed3f34be076442ca85e6413603f97dc1d1f91d2a1abd8258b914c3fd7ef12
+size 1245

--- a/sample_papers/ECE/3/final/Embedded_Systems.pdf
+++ b/sample_papers/ECE/3/final/Embedded_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc94fc66123a6d1035f948cf8575452ee53c169702e12f524619f32d78befcb1
+size 1247

--- a/sample_papers/ECE/3/final/Microprocessors.pdf
+++ b/sample_papers/ECE/3/final/Microprocessors.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e23bf249cccf45b8c829758480769a8570bb4affb6d18b63adcaaab64969810c
+size 1245

--- a/sample_papers/ECE/3/final/VLSI_Design.pdf
+++ b/sample_papers/ECE/3/final/VLSI_Design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b921adf33470d75dd2db97da975b8e7a391290f6601f8e08634a2fad2e7dc65
+size 1239

--- a/sample_papers/ECE/3/mid/Communication_Systems.pdf
+++ b/sample_papers/ECE/3/mid/Communication_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a226346f0091166fe485bc922efd4effccb3f4dc78e6c85c22b410ba52b05edd
+size 1261

--- a/sample_papers/ECE/3/mid/Control_Systems.pdf
+++ b/sample_papers/ECE/3/mid/Control_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf3c17df9e2bc679a7b5e40df7658a2cd1d494fd3a89da1114722f1fec6e485a
+size 1248

--- a/sample_papers/ECE/3/mid/Embedded_Systems.pdf
+++ b/sample_papers/ECE/3/mid/Embedded_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ffd9214610bea5ef899e785e84a8e308435812f5179e2345ec30f75a1c9bce9
+size 1251

--- a/sample_papers/ECE/3/mid/Microprocessors.pdf
+++ b/sample_papers/ECE/3/mid/Microprocessors.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60315b4b58799f02574c0a7411c279d740850bde96a3634dd9b25f350cf16d17
+size 1249

--- a/sample_papers/ECE/3/mid/VLSI_Design.pdf
+++ b/sample_papers/ECE/3/mid/VLSI_Design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35c734686e07ed03337c573af2cd8f48ad2d4433a67c19206ae36eabe4ecd374
+size 1243

--- a/sample_papers/ECE/3/mock/Communication_Systems.pdf
+++ b/sample_papers/ECE/3/mock/Communication_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:befac880388700e7df150488940d54cbe22f5c86c65191d2914199a60a51993f
+size 1257

--- a/sample_papers/ECE/3/mock/Control_Systems.pdf
+++ b/sample_papers/ECE/3/mock/Control_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36bdf93077b3cdfb87054c8015b37f2cec462a8764cf42a53c53c2795c5027ae
+size 1244

--- a/sample_papers/ECE/3/mock/Embedded_Systems.pdf
+++ b/sample_papers/ECE/3/mock/Embedded_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc157ee541f4f0d6bbf7a43549137d51d1788dde81f27f29d074be03c1bad5b6
+size 1247

--- a/sample_papers/ECE/3/mock/Microprocessors.pdf
+++ b/sample_papers/ECE/3/mock/Microprocessors.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5b2aba4dfc807f95be03cf441eaa673637cc21ce6c88b8be4f6acd8654af91a
+size 1241

--- a/sample_papers/ECE/3/mock/VLSI_Design.pdf
+++ b/sample_papers/ECE/3/mock/VLSI_Design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04a6c0a4dd89b0f7db9a8e7f4f34c420207a87c455df1ca207a69bc562bb5ab2
+size 1237

--- a/sample_papers/ECE/3/quiz/Communication_Systems.pdf
+++ b/sample_papers/ECE/3/quiz/Communication_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8dc51a04c67b6d5cf4dc4b456f028137f5884d71f39fbc9c0501d6566da3acae
+size 1246

--- a/sample_papers/ECE/3/quiz/Control_Systems.pdf
+++ b/sample_papers/ECE/3/quiz/Control_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e875065365c2a1e9f7b99c0033e1149abfedd3ed82667d6bd39565a234681cf2
+size 1236

--- a/sample_papers/ECE/3/quiz/Embedded_Systems.pdf
+++ b/sample_papers/ECE/3/quiz/Embedded_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc275a44bf9196929b1a11740e1d1d21cb6cac8cc2bdd2981267d3dc872cb09c
+size 1238

--- a/sample_papers/ECE/3/quiz/Microprocessors.pdf
+++ b/sample_papers/ECE/3/quiz/Microprocessors.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:769c3e51f19bc598b5923698915d2a2250270e62bd17bd6252a60d9b3d48d140
+size 1236

--- a/sample_papers/ECE/3/quiz/VLSI_Design.pdf
+++ b/sample_papers/ECE/3/quiz/VLSI_Design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eea334e83b663b0a088d0449d5253a88553d20dc09190517259fbfdd04575698
+size 1230

--- a/sample_papers/ECE/4/final/Antenna_Theory.pdf
+++ b/sample_papers/ECE/4/final/Antenna_Theory.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb24e46c379da4355bad8f453ae3bdb20e62e6fb467f4e7ed612a6f31c097447
+size 1242

--- a/sample_papers/ECE/4/final/Microwave_Engineering.pdf
+++ b/sample_papers/ECE/4/final/Microwave_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e671ad1a8bfc9965bbd61f036023322933118451031627dc2a8aa19cea9eb52
+size 1257

--- a/sample_papers/ECE/4/final/Optical_Communication.pdf
+++ b/sample_papers/ECE/4/final/Optical_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d031096ba2f95e0329001709cb2ea286a5c4a0a8f26e78fa04526817b48f368b
+size 1257

--- a/sample_papers/ECE/4/final/Project_Work.pdf
+++ b/sample_papers/ECE/4/final/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50e5efe7b0c94ccac4d43a4a89714c53cfb5ebb1175c8fce61f52e0678efc375
+size 1241

--- a/sample_papers/ECE/4/final/Wireless_Communication.pdf
+++ b/sample_papers/ECE/4/final/Wireless_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c753ff93f3c1995ecebb785e6b68e057d08f4f4a66e75c5c01b397312f4d65b9
+size 1258

--- a/sample_papers/ECE/4/mid/Antenna_Theory.pdf
+++ b/sample_papers/ECE/4/mid/Antenna_Theory.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b40db58487ce5ef8f66883025865a533333dee055b75fd911c4d861bb1aea19a
+size 1248

--- a/sample_papers/ECE/4/mid/Microwave_Engineering.pdf
+++ b/sample_papers/ECE/4/mid/Microwave_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b609453d4be6bdde066e2affae3f81c3d01f6a092f31c9fe892a1b24408217f
+size 1260

--- a/sample_papers/ECE/4/mid/Optical_Communication.pdf
+++ b/sample_papers/ECE/4/mid/Optical_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d35bd1269ffc18ca6d1d32671b1da9eb0a971cea94dac773c4717533bea0d313
+size 1262

--- a/sample_papers/ECE/4/mid/Project_Work.pdf
+++ b/sample_papers/ECE/4/mid/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d56be5d012f06a8b03f56c3234de96bda4bf199d3fa7c0f7f91f3bdf898e3577
+size 1244

--- a/sample_papers/ECE/4/mid/Wireless_Communication.pdf
+++ b/sample_papers/ECE/4/mid/Wireless_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20f2eb125acf1c7b8a3a112ef9d4fa36b2b040ee1caf1ccbcd510d8cba9a8619
+size 1263

--- a/sample_papers/ECE/4/mock/Antenna_Theory.pdf
+++ b/sample_papers/ECE/4/mock/Antenna_Theory.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85246dc9ef16896a148ad9949abfbcff79688ddf8f6afdffaeea7a1d0a5edc37
+size 1242

--- a/sample_papers/ECE/4/mock/Microwave_Engineering.pdf
+++ b/sample_papers/ECE/4/mock/Microwave_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d783fb81fc246a73a6882282bd2b629d50d5b66e1262b3475a556b96d964d2b9
+size 1254

--- a/sample_papers/ECE/4/mock/Optical_Communication.pdf
+++ b/sample_papers/ECE/4/mock/Optical_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8d7dce50e6e42546583747120a2f90037660bc53b08825114a935a9d5f6860b
+size 1257

--- a/sample_papers/ECE/4/mock/Project_Work.pdf
+++ b/sample_papers/ECE/4/mock/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1682335ac8e9a7e9fbc10eb9cda7cec38474d8700919727ca25dd833bbb51b7
+size 1238

--- a/sample_papers/ECE/4/mock/Wireless_Communication.pdf
+++ b/sample_papers/ECE/4/mock/Wireless_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f1362cdd856f703777325e5c4e684c493b2ba3682d5c7574883adf1e6a42c5e
+size 1258

--- a/sample_papers/ECE/4/quiz/Antenna_Theory.pdf
+++ b/sample_papers/ECE/4/quiz/Antenna_Theory.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:652aa8911b784836a9c4a82f307e3e25cc1377dc6e5e83153faa70ae6747bd61
+size 1235

--- a/sample_papers/ECE/4/quiz/Microwave_Engineering.pdf
+++ b/sample_papers/ECE/4/quiz/Microwave_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bcb24be466ecd055419bb571c84023762b6faccaa89489f1101842001e3368c
+size 1248

--- a/sample_papers/ECE/4/quiz/Optical_Communication.pdf
+++ b/sample_papers/ECE/4/quiz/Optical_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af9d04efdfda2325f80ec79bfda69ca487137c358e2ca4eb7ebc8d365ef40058
+size 1246

--- a/sample_papers/ECE/4/quiz/Project_Work.pdf
+++ b/sample_papers/ECE/4/quiz/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:077e274d1d95966df9a50151617d911da7291e3c710d2225ddbd783b88f71528
+size 1231

--- a/sample_papers/ECE/4/quiz/Wireless_Communication.pdf
+++ b/sample_papers/ECE/4/quiz/Wireless_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfe934bbfd6bb731e74d9179d676846927532ad55fc9225dea3fb9f11b583688
+size 1248

--- a/sample_papers/EEE/1/final/Basic_Electrical_Engineering.pdf
+++ b/sample_papers/EEE/1/final/Basic_Electrical_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74e74ff6c3c891859c6ed7af3e4c1da2a838ffff51b364df31f243511200f001
+size 1265

--- a/sample_papers/EEE/1/final/Engineering_Chemistry.pdf
+++ b/sample_papers/EEE/1/final/Engineering_Chemistry.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af268e3e527bd6082c5029a3f6dbba94885dcee26e30f17d1619d5e5a72ec32d
+size 1254

--- a/sample_papers/EEE/1/final/Engineering_Graphics.pdf
+++ b/sample_papers/EEE/1/final/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e62c5b03d4315417ec0a0f182443bae859dd6ab90c1be2e244ea1de571a83aec
+size 1252

--- a/sample_papers/EEE/1/final/English_Communication.pdf
+++ b/sample_papers/EEE/1/final/English_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0d2f2804104296f794e0efd565a962d246573433ff8075e5db3168148290284
+size 1254

--- a/sample_papers/EEE/1/final/Mathematics-I.pdf
+++ b/sample_papers/EEE/1/final/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37bb4cac821729318d0cb689bf3a0b151930e818ea92a9ceb8e2cee9597a9612
+size 1242

--- a/sample_papers/EEE/1/mid/Basic_Electrical_Engineering.pdf
+++ b/sample_papers/EEE/1/mid/Basic_Electrical_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620291ca51a3664aabff8cc34b417b8a03167e7be6e4252469dddceb5422150e
+size 1273

--- a/sample_papers/EEE/1/mid/Engineering_Chemistry.pdf
+++ b/sample_papers/EEE/1/mid/Engineering_Chemistry.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dda27a61c8d50628499cfa5159d0218aac2ad2d68ab5e6f5cd21a0df4696effc
+size 1264

--- a/sample_papers/EEE/1/mid/Engineering_Graphics.pdf
+++ b/sample_papers/EEE/1/mid/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:562d105a203aa3c7d21d3dc038d42ca70324a4bcae3f27ae2093c0df6fb7fb53
+size 1258

--- a/sample_papers/EEE/1/mid/English_Communication.pdf
+++ b/sample_papers/EEE/1/mid/English_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39a65cabc5f68df1c8688665ec3e182214e04e2dd37c0064ff67b69ea1495350
+size 1261

--- a/sample_papers/EEE/1/mid/Mathematics-I.pdf
+++ b/sample_papers/EEE/1/mid/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f92f128c3a1a9a73fa0e914adcffd8b7ee0a9b860bc3e1b0bead962bf44628ee
+size 1245

--- a/sample_papers/EEE/1/mock/Basic_Electrical_Engineering.pdf
+++ b/sample_papers/EEE/1/mock/Basic_Electrical_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a1ff5e428673d8bc183bb003ae6aa96a7f73af9896f1293b94721f2ebf4be5d
+size 1265

--- a/sample_papers/EEE/1/mock/Engineering_Chemistry.pdf
+++ b/sample_papers/EEE/1/mock/Engineering_Chemistry.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7463c2896f37c71b878a50e7166f0ae8affae2f25f979d31a108626f60cdc25
+size 1256

--- a/sample_papers/EEE/1/mock/Engineering_Graphics.pdf
+++ b/sample_papers/EEE/1/mock/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34043250fa3880bbd326101b13a184c6a5762e02149040d3cd66558176359a17
+size 1252

--- a/sample_papers/EEE/1/mock/English_Communication.pdf
+++ b/sample_papers/EEE/1/mock/English_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22ac1c041c3b3e21b70c8c22b441997d556833a5567233037c0b551f49e56247
+size 1254

--- a/sample_papers/EEE/1/mock/Mathematics-I.pdf
+++ b/sample_papers/EEE/1/mock/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7f59923114ac1692a66f7138c8a726a749c8d248dbc547f6767b5bc1bf3c15d
+size 1239

--- a/sample_papers/EEE/1/quiz/Basic_Electrical_Engineering.pdf
+++ b/sample_papers/EEE/1/quiz/Basic_Electrical_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d6879d5e35226acf80ea4cce8c3b8cca14e34d631fc3963b86624aa97527583
+size 1258

--- a/sample_papers/EEE/1/quiz/Engineering_Chemistry.pdf
+++ b/sample_papers/EEE/1/quiz/Engineering_Chemistry.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2722fd58011de8b600762a11c3045a8b5da0b3e93c7f22b7b26c14d3c901f4f5
+size 1245

--- a/sample_papers/EEE/1/quiz/Engineering_Graphics.pdf
+++ b/sample_papers/EEE/1/quiz/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21cc6469e6bffd192ca0f88eb6674eb8c636daea92e3f89cce78b6fc9e2d082d
+size 1244

--- a/sample_papers/EEE/1/quiz/English_Communication.pdf
+++ b/sample_papers/EEE/1/quiz/English_Communication.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6283033181e8844e613bb97928a9a3fa5941e5494ac7f0f26a1a62a61a6ecf17
+size 1245

--- a/sample_papers/EEE/1/quiz/Mathematics-I.pdf
+++ b/sample_papers/EEE/1/quiz/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb234faf399c53441fedbd863853585f1115b7aa8920164396885f1d7738dbea
+size 1233

--- a/sample_papers/EEE/2/final/Analog_Electronics.pdf
+++ b/sample_papers/EEE/2/final/Analog_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89f17810b8c98ce33167db54a8e2a4348d5a2dd1a56d56667f96964a4e726078
+size 1249

--- a/sample_papers/EEE/2/final/Circuit_Theory.pdf
+++ b/sample_papers/EEE/2/final/Circuit_Theory.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b2ee33a64c22dfb15b4e195d857e22cbbec9158c77d6d7d8dc8bd0102f89a6d
+size 1241

--- a/sample_papers/EEE/2/final/Digital_Electronics.pdf
+++ b/sample_papers/EEE/2/final/Digital_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b702fa9487914ecca751d178fa832b6260a4e929b730996db8273b68974420e
+size 1251

--- a/sample_papers/EEE/2/final/Electromagnetic_Fields.pdf
+++ b/sample_papers/EEE/2/final/Electromagnetic_Fields.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2d0e30bb4b4f673ff61e45d69e013e2eb53f74a8af5390c137e0cb1d3c335ad
+size 1258

--- a/sample_papers/EEE/2/final/Signals_and_Systems.pdf
+++ b/sample_papers/EEE/2/final/Signals_and_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90f0714c13cdaa6e1d3d599d49edcf1a84f37ecbfc492c6bd5bcb49f540f3a0b
+size 1252

--- a/sample_papers/EEE/2/mid/Analog_Electronics.pdf
+++ b/sample_papers/EEE/2/mid/Analog_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af032784c67ea82fa6c06e842bf7df526d607698623549e8503de5c4cb83751f
+size 1256

--- a/sample_papers/EEE/2/mid/Circuit_Theory.pdf
+++ b/sample_papers/EEE/2/mid/Circuit_Theory.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da5939af9e10d9d5909b44e35b63ee6e7f5f5d7ec645058901a248dc234711b0
+size 1248

--- a/sample_papers/EEE/2/mid/Digital_Electronics.pdf
+++ b/sample_papers/EEE/2/mid/Digital_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0be2feef6606ca98e1f4f927eff1ed78469b41a275211439e63b86adec98fe0f
+size 1258

--- a/sample_papers/EEE/2/mid/Electromagnetic_Fields.pdf
+++ b/sample_papers/EEE/2/mid/Electromagnetic_Fields.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ed7c1020b69845f3f52ea92df6bc9f6fad2c602c5a676d5e3b922e588ea8a44
+size 1263

--- a/sample_papers/EEE/2/mid/Signals_and_Systems.pdf
+++ b/sample_papers/EEE/2/mid/Signals_and_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:998f896201f808e1e5f87936f3d0eefc86ac8476d404fb21c7a32203aa3422cb
+size 1257

--- a/sample_papers/EEE/2/mock/Analog_Electronics.pdf
+++ b/sample_papers/EEE/2/mock/Analog_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f431d6d7a10bd2f4a7e740b009c360b48c70951a35d9f374850d5ddffc90294
+size 1248

--- a/sample_papers/EEE/2/mock/Circuit_Theory.pdf
+++ b/sample_papers/EEE/2/mock/Circuit_Theory.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fd0ada7fd2053c95990dd91bfd4e690454809dc3d751a28783d4138166be2c2
+size 1241

--- a/sample_papers/EEE/2/mock/Digital_Electronics.pdf
+++ b/sample_papers/EEE/2/mock/Digital_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee570120cbbc6c0def717fa30672569e452945f07ba181c4fa41c60aa19058e1
+size 1252

--- a/sample_papers/EEE/2/mock/Electromagnetic_Fields.pdf
+++ b/sample_papers/EEE/2/mock/Electromagnetic_Fields.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0657d93ac37692cd8fc66df2d9de3657ba1dd6b9a7391570e5b5b45d04b0ad91
+size 1257

--- a/sample_papers/EEE/2/mock/Signals_and_Systems.pdf
+++ b/sample_papers/EEE/2/mock/Signals_and_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26e103dab2e37ddd11c1c1d79b4d2bcd8498d69c9751c42e8c477d646730ec35
+size 1252

--- a/sample_papers/EEE/2/quiz/Analog_Electronics.pdf
+++ b/sample_papers/EEE/2/quiz/Analog_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:904a79f5a5d02dbbd6cd291b7945c9fb6cd3e706ebe72bfff45ab0d734c63177
+size 1242

--- a/sample_papers/EEE/2/quiz/Circuit_Theory.pdf
+++ b/sample_papers/EEE/2/quiz/Circuit_Theory.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:307172b27b46645a4edc0db41d4beedfb04bf91dd170570420c5c87f9b42b005
+size 1234

--- a/sample_papers/EEE/2/quiz/Digital_Electronics.pdf
+++ b/sample_papers/EEE/2/quiz/Digital_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:093994d15e1d99b7a7016ee1b22e3dc73151fc51f9bb941c70b6925f9aa7dbc3
+size 1241

--- a/sample_papers/EEE/2/quiz/Electromagnetic_Fields.pdf
+++ b/sample_papers/EEE/2/quiz/Electromagnetic_Fields.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12ce1b20ad418fd4a31e0ead5c397138a616f8ceaa091b78d77e0ec3a8c4c59b
+size 1248

--- a/sample_papers/EEE/2/quiz/Signals_and_Systems.pdf
+++ b/sample_papers/EEE/2/quiz/Signals_and_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abe631cefa3ef453701f2e6c824e9510337157bca1f164bc46382535fb9d04b0
+size 1243

--- a/sample_papers/EEE/3/final/Control_Systems.pdf
+++ b/sample_papers/EEE/3/final/Control_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9df600a776f310e31e0506e5bc00362b2590137519485c314363cf9cd055f693
+size 1245

--- a/sample_papers/EEE/3/final/Electrical_Machines.pdf
+++ b/sample_papers/EEE/3/final/Electrical_Machines.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e5269ecda3b3d86e0e2b9e7189c425c32b54bb48826819a6bc4e5bd61372393
+size 1252

--- a/sample_papers/EEE/3/final/Microprocessors.pdf
+++ b/sample_papers/EEE/3/final/Microprocessors.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9289c2cd336dcd7a87c22bb8c1db6f3c4c99f5089ebf23b194d5adf55e96c33a
+size 1245

--- a/sample_papers/EEE/3/final/Power_Electronics.pdf
+++ b/sample_papers/EEE/3/final/Power_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26dead735e3c8276f6e69e9b6df73da91c0761b3c67eef69cb10a80cb77de502
+size 1248

--- a/sample_papers/EEE/3/final/Power_Systems.pdf
+++ b/sample_papers/EEE/3/final/Power_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:728dfa882ff956a2420207243fd2e0c703832884e7117a7ae532e6de73eb0749
+size 1242

--- a/sample_papers/EEE/3/mid/Control_Systems.pdf
+++ b/sample_papers/EEE/3/mid/Control_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d659c4223a253f15445f77eccec4b23d3be23923b97bae1b2db25bc74c02d16
+size 1248

--- a/sample_papers/EEE/3/mid/Electrical_Machines.pdf
+++ b/sample_papers/EEE/3/mid/Electrical_Machines.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1e6caad0ce07013517413f469c1625a89f3697037055ea7ffb60d0d08f806ad
+size 1257

--- a/sample_papers/EEE/3/mid/Microprocessors.pdf
+++ b/sample_papers/EEE/3/mid/Microprocessors.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d763d9383a42078a887b968d1435b9bacf894af28c62c52e85df18b3667ad04
+size 1248

--- a/sample_papers/EEE/3/mid/Power_Electronics.pdf
+++ b/sample_papers/EEE/3/mid/Power_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec53e8b60f366888e0bcbaa15b0868eb9d267872792f18434e350d5b396a3004
+size 1253

--- a/sample_papers/EEE/3/mid/Power_Systems.pdf
+++ b/sample_papers/EEE/3/mid/Power_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9403fd8ebe00dce3537aea941e87c95597534c99c44013a9e516d94535175f32
+size 1246

--- a/sample_papers/EEE/3/mock/Control_Systems.pdf
+++ b/sample_papers/EEE/3/mock/Control_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:271ad7326fdad7847062b433b0dec86968e7e7fcaf33b6a5761fa9837c51f322
+size 1244

--- a/sample_papers/EEE/3/mock/Electrical_Machines.pdf
+++ b/sample_papers/EEE/3/mock/Electrical_Machines.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43b02bb503c0db5b6d48e1d0b3586babaec80420d9adabd899a48882fa774334
+size 1250

--- a/sample_papers/EEE/3/mock/Microprocessors.pdf
+++ b/sample_papers/EEE/3/mock/Microprocessors.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:754a4f17869bea98381dae71a8fd10a04df2a5182c14fddfa27eecba1896f0fe
+size 1241

--- a/sample_papers/EEE/3/mock/Power_Electronics.pdf
+++ b/sample_papers/EEE/3/mock/Power_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:126fd36c57a995be688b00231afe23cdc90fe668f2d3097d64a8ccdcc3fd8b3b
+size 1247

--- a/sample_papers/EEE/3/mock/Power_Systems.pdf
+++ b/sample_papers/EEE/3/mock/Power_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23a69246aa9ad434805a496aa7e23ec36f04d8ef118d24811eec157cc3becb11
+size 1241

--- a/sample_papers/EEE/3/quiz/Control_Systems.pdf
+++ b/sample_papers/EEE/3/quiz/Control_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fd228e28a50e0e5f9e6e3b6e0ffae1642a2874c7936871cb4a8f52b2fdbc045
+size 1236

--- a/sample_papers/EEE/3/quiz/Electrical_Machines.pdf
+++ b/sample_papers/EEE/3/quiz/Electrical_Machines.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:deebd8ba39e7806de24caf127a66577b61ab2a729f736c498159d8a0d43e0bfe
+size 1242

--- a/sample_papers/EEE/3/quiz/Microprocessors.pdf
+++ b/sample_papers/EEE/3/quiz/Microprocessors.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e176c956e277f6b112bd58759f01f720b3cfa9ef516d356b76f50c0c0f24c60
+size 1236

--- a/sample_papers/EEE/3/quiz/Power_Electronics.pdf
+++ b/sample_papers/EEE/3/quiz/Power_Electronics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7039216cfc7e9e65e652f9dd02f0cfca000641ad990f6bb3b406291a1ab6b6d3
+size 1239

--- a/sample_papers/EEE/3/quiz/Power_Systems.pdf
+++ b/sample_papers/EEE/3/quiz/Power_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2169f021fa5446b56123dc0adb5ff71f7c0f9c97a54bbb085a45e565a0376b2c
+size 1233

--- a/sample_papers/EEE/4/final/Electrical_Drives.pdf
+++ b/sample_papers/EEE/4/final/Electrical_Drives.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6149743cf806f431611ae64994732f48e1639a50d74efea5f452f773fc21003
+size 1246

--- a/sample_papers/EEE/4/final/High_Voltage_Engineering.pdf
+++ b/sample_papers/EEE/4/final/High_Voltage_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1408d515f5e3cea76f65cbdf93e10b6eeda976524146077aec8970930316685
+size 1262

--- a/sample_papers/EEE/4/final/Project_Work.pdf
+++ b/sample_papers/EEE/4/final/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a62e38b1a30924a08f329d9085657003a2f33f350d29f83db52c22958af08300
+size 1240

--- a/sample_papers/EEE/4/final/Renewable_Energy_Systems.pdf
+++ b/sample_papers/EEE/4/final/Renewable_Energy_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8703f562e9ca5af8ab1c28761c5d2a98b822aeef76a3674477935b82c5209e73
+size 1266

--- a/sample_papers/EEE/4/final/Smart_Grid.pdf
+++ b/sample_papers/EEE/4/final/Smart_Grid.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:daa796f9b5124011fc650055ae590171024145405b27346cee50f5af591eaf5f
+size 1235

--- a/sample_papers/EEE/4/mid/Electrical_Drives.pdf
+++ b/sample_papers/EEE/4/mid/Electrical_Drives.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b870d9611ea68f91f1ac4ab45db47797c6529db3c135802d8c9255eef4552aa
+size 1253

--- a/sample_papers/EEE/4/mid/High_Voltage_Engineering.pdf
+++ b/sample_papers/EEE/4/mid/High_Voltage_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3311525488bd991ec9b6bd5428af7634eca5951aae3f10a2343417b4b8775c7b
+size 1266

--- a/sample_papers/EEE/4/mid/Project_Work.pdf
+++ b/sample_papers/EEE/4/mid/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ee5646233e44b17c69109471d623a82b8d811bd53d02cf66a53c09d2b9be7d3
+size 1244

--- a/sample_papers/EEE/4/mid/Renewable_Energy_Systems.pdf
+++ b/sample_papers/EEE/4/mid/Renewable_Energy_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe7961c9eca169eb9b01838c9badce2a6a84d7566f9f489e94fe8f7c21cb13fb
+size 1266

--- a/sample_papers/EEE/4/mid/Smart_Grid.pdf
+++ b/sample_papers/EEE/4/mid/Smart_Grid.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ce6f654e128ee1fa289f40b103d63465a2b8c0544170de3f7af49ab988b7a7a
+size 1239

--- a/sample_papers/EEE/4/mock/Electrical_Drives.pdf
+++ b/sample_papers/EEE/4/mock/Electrical_Drives.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06ff6e4aeecca2aa4d7b2edd103e930c87d334f7dc8b46e4147582f293bbb3de
+size 1245

--- a/sample_papers/EEE/4/mock/High_Voltage_Engineering.pdf
+++ b/sample_papers/EEE/4/mock/High_Voltage_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79d179e80e6d22e1bc0705f0c51ab0f4bc024cf07f69499f4fc3401532941523
+size 1260

--- a/sample_papers/EEE/4/mock/Project_Work.pdf
+++ b/sample_papers/EEE/4/mock/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d766b4715ef240427d34f4161b461df504018f977539d0a5b3ffe9eb8636e9c0
+size 1237

--- a/sample_papers/EEE/4/mock/Renewable_Energy_Systems.pdf
+++ b/sample_papers/EEE/4/mock/Renewable_Energy_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4329dbf0eb3dd6ed65759bbd423a6eeb5166e322be0d55a145d9f50d513e794
+size 1265

--- a/sample_papers/EEE/4/mock/Smart_Grid.pdf
+++ b/sample_papers/EEE/4/mock/Smart_Grid.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5d3d510e11ed9acfd84070da106ac5d4b0091cf0480d32b0db71b1c3e445dd4
+size 1234

--- a/sample_papers/EEE/4/quiz/Electrical_Drives.pdf
+++ b/sample_papers/EEE/4/quiz/Electrical_Drives.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af6a212a8dfcb9aabed7e61a695928a68a2446493f98f24186550e48916ed38b
+size 1238

--- a/sample_papers/EEE/4/quiz/High_Voltage_Engineering.pdf
+++ b/sample_papers/EEE/4/quiz/High_Voltage_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76e07923c07bdb67f4930675a1426893997fbccf265790f21121f6a8decc18b7
+size 1252

--- a/sample_papers/EEE/4/quiz/Project_Work.pdf
+++ b/sample_papers/EEE/4/quiz/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63dd1037b8e44208717a8f37804a1de65fec51e5d74781ac43b1fd97865df01d
+size 1231

--- a/sample_papers/EEE/4/quiz/Renewable_Energy_Systems.pdf
+++ b/sample_papers/EEE/4/quiz/Renewable_Energy_Systems.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cefc1b6ca88f55f75d91a2f1155f727552075928ebbc3179c393c47a505b3311
+size 1252

--- a/sample_papers/EEE/4/quiz/Smart_Grid.pdf
+++ b/sample_papers/EEE/4/quiz/Smart_Grid.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2395af54d38221cd59fa8162b275e001a509705b046c61d9da9b68dbcaf5968
+size 1227

--- a/sample_papers/MECH/1/final/Engineering_Graphics.pdf
+++ b/sample_papers/MECH/1/final/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f531108ce360cce4c67cc8ae0b243551c80350fffeb24719bf5d1530387ea531
+size 1256

--- a/sample_papers/MECH/1/final/Engineering_Mechanics.pdf
+++ b/sample_papers/MECH/1/final/Engineering_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eb9047bb8fd03b7759d55af07a6589a33d20663122ade5d5b6f0454582a5946
+size 1257

--- a/sample_papers/MECH/1/final/Engineering_Physics.pdf
+++ b/sample_papers/MECH/1/final/Engineering_Physics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12a71c17764341bfa54402f07b634f5be1bd4aa8277f360e689f6ca9c1140c25
+size 1261

--- a/sample_papers/MECH/1/final/Mathematics-I.pdf
+++ b/sample_papers/MECH/1/final/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:230d844c122e342b501fa2e58a10a37b5a8577e92ef263c4ca6e272c54762598
+size 1243

--- a/sample_papers/MECH/1/final/Workshop_Practice.pdf
+++ b/sample_papers/MECH/1/final/Workshop_Practice.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3615a39bc1bfd9fdbdd7435bdf74125450b296191cfec6f8881d093da7c9d0a9
+size 1251

--- a/sample_papers/MECH/1/mid/Engineering_Graphics.pdf
+++ b/sample_papers/MECH/1/mid/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:200dd2227a4c2a6aaaee2eae1dfebf01b4c4717255eb4d5de901ae74c0d0e3de
+size 1260

--- a/sample_papers/MECH/1/mid/Engineering_Mechanics.pdf
+++ b/sample_papers/MECH/1/mid/Engineering_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:211c41529b2d069c65fc9d21ab31a1b58b8770bcbcabbde0e722d6d73f38d305
+size 1265

--- a/sample_papers/MECH/1/mid/Engineering_Physics.pdf
+++ b/sample_papers/MECH/1/mid/Engineering_Physics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8161e534f36b94263282ae6981d9f66e69a1060c803e6e9208242f85ae349935
+size 1260

--- a/sample_papers/MECH/1/mid/Mathematics-I.pdf
+++ b/sample_papers/MECH/1/mid/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b70a06d9f20d59bba20fec69b1799b23e6ee61157ac591f0d87dcb9d0dfd9c2
+size 1247

--- a/sample_papers/MECH/1/mid/Workshop_Practice.pdf
+++ b/sample_papers/MECH/1/mid/Workshop_Practice.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f31a7ac66464f8bb87b3ec3f7629eb010836fad6fe5530dc8b9481b54145abc6
+size 1256

--- a/sample_papers/MECH/1/mock/Engineering_Graphics.pdf
+++ b/sample_papers/MECH/1/mock/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:619833c3aaafc3895a852cb11de385288b4b25bdf70e3d3919fe2c71994d612b
+size 1254

--- a/sample_papers/MECH/1/mock/Engineering_Mechanics.pdf
+++ b/sample_papers/MECH/1/mock/Engineering_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0ea15bef793092fd7ef9d430ac20190b8aed1bcf136c5d7347f76c1f5b6e81b
+size 1254

--- a/sample_papers/MECH/1/mock/Engineering_Physics.pdf
+++ b/sample_papers/MECH/1/mock/Engineering_Physics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04acb8c1866930e5a45383f007e14b4c0af2e4d7c3d2effa9d1ad5b3d865411d
+size 1253

--- a/sample_papers/MECH/1/mock/Mathematics-I.pdf
+++ b/sample_papers/MECH/1/mock/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:788cd0be9222b6b3c38c35c7561af59be7b1b7ac343ab300b866fda2a53993c8
+size 1240

--- a/sample_papers/MECH/1/mock/Workshop_Practice.pdf
+++ b/sample_papers/MECH/1/mock/Workshop_Practice.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:170e757ddfa2be000f65dcf33b1f4d2c8336090d1f5d64a4fa857d1235c1f65a
+size 1248

--- a/sample_papers/MECH/1/quiz/Engineering_Graphics.pdf
+++ b/sample_papers/MECH/1/quiz/Engineering_Graphics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c1afbd45fd4121c80eba07be4271ae25e7cf74752b59b4fd241499519707c82
+size 1246

--- a/sample_papers/MECH/1/quiz/Engineering_Mechanics.pdf
+++ b/sample_papers/MECH/1/quiz/Engineering_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c71327388cb7dd269a19bfb0c5144a2ab549c46da9d4e7a538e3f8d80800b62a
+size 1248

--- a/sample_papers/MECH/1/quiz/Engineering_Physics.pdf
+++ b/sample_papers/MECH/1/quiz/Engineering_Physics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8129eb8c3da38016123cf51c36256de68adbd039b2a0caf0366a3d4c1edff031
+size 1245

--- a/sample_papers/MECH/1/quiz/Mathematics-I.pdf
+++ b/sample_papers/MECH/1/quiz/Mathematics-I.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf29a0439c1c2d8705963aaaa3358d731de16aeff1d38c5922fe28a337a7fc07
+size 1235

--- a/sample_papers/MECH/1/quiz/Workshop_Practice.pdf
+++ b/sample_papers/MECH/1/quiz/Workshop_Practice.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a0354f07066bea126aedeac8be9c2d057920519439a4ba767517a8be91eda43
+size 1242

--- a/sample_papers/MECH/2/final/Fluid_Mechanics.pdf
+++ b/sample_papers/MECH/2/final/Fluid_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5938561c48d2bdf58eaa2688937e28594716e812b45ffdcd0e088cffb0af3c8c
+size 1244

--- a/sample_papers/MECH/2/final/Machine_Drawing.pdf
+++ b/sample_papers/MECH/2/final/Machine_Drawing.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:442354750d0df6086e9efd4b4d9ecc28ee4290e4d6b29f52a22fde86703ff77c
+size 1247

--- a/sample_papers/MECH/2/final/Manufacturing_Processes.pdf
+++ b/sample_papers/MECH/2/final/Manufacturing_Processes.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61dabcacbe208c2067d6045c6342223185dbf79fc7b81106a337e5c757f4910f
+size 1267

--- a/sample_papers/MECH/2/final/Strength_of_Materials.pdf
+++ b/sample_papers/MECH/2/final/Strength_of_Materials.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d296aa11a1de58092519f7f96e3f5f9890e6c0b0536cb3f4c3fe497a024504c5
+size 1258

--- a/sample_papers/MECH/2/final/Thermodynamics.pdf
+++ b/sample_papers/MECH/2/final/Thermodynamics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9b4f6adb398dded426e93a191a673f941437b4f1f598ce2763b777d934fe944
+size 1244

--- a/sample_papers/MECH/2/mid/Fluid_Mechanics.pdf
+++ b/sample_papers/MECH/2/mid/Fluid_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26320bdb435e34c2e7589de73de8c7ec17aa1fdd411b149ba78080126ae5283e
+size 1250

--- a/sample_papers/MECH/2/mid/Machine_Drawing.pdf
+++ b/sample_papers/MECH/2/mid/Machine_Drawing.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9717a772401751c36ba7cf1ca51366c6ca1b1e79cbcb16e0e1f4f52eca4018dd
+size 1251

--- a/sample_papers/MECH/2/mid/Manufacturing_Processes.pdf
+++ b/sample_papers/MECH/2/mid/Manufacturing_Processes.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b797211697881d0fec8aa3e14ef1a1c16719ff60a357a95b36e4eb11894aa280
+size 1267

--- a/sample_papers/MECH/2/mid/Strength_of_Materials.pdf
+++ b/sample_papers/MECH/2/mid/Strength_of_Materials.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72f25a8962d6f219c985f64b5705ccf5c024d0dfbb2cc7ec7607e5578df0f672
+size 1261

--- a/sample_papers/MECH/2/mid/Thermodynamics.pdf
+++ b/sample_papers/MECH/2/mid/Thermodynamics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cc51ca4710c8e59d1fe13e58709308405386b5297889630d69ff86eed9b2b57
+size 1248

--- a/sample_papers/MECH/2/mock/Fluid_Mechanics.pdf
+++ b/sample_papers/MECH/2/mock/Fluid_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6430ad3ba827209e41cf118babdb8a5aff85ba92c0bd0e16e5394896ceeb1c94
+size 1243

--- a/sample_papers/MECH/2/mock/Machine_Drawing.pdf
+++ b/sample_papers/MECH/2/mock/Machine_Drawing.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fde8b665c21fd3237bbf9fc533de58ef26048b71a9a02ac129fd213181508c97
+size 1244

--- a/sample_papers/MECH/2/mock/Manufacturing_Processes.pdf
+++ b/sample_papers/MECH/2/mock/Manufacturing_Processes.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31ca2c21d2a09d02c8c35e34849bfbdbc9affd6058be5b5728b0b6393782073b
+size 1261

--- a/sample_papers/MECH/2/mock/Strength_of_Materials.pdf
+++ b/sample_papers/MECH/2/mock/Strength_of_Materials.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3eb4436f14cc8c75cf448eec5d0f227b8a53e2a3dde0bfe173d30fa14e3f868f
+size 1257

--- a/sample_papers/MECH/2/mock/Thermodynamics.pdf
+++ b/sample_papers/MECH/2/mock/Thermodynamics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:314dbe065f66bc55f441eac277ec0458ce53709841e053de048d80c97189d88b
+size 1242

--- a/sample_papers/MECH/2/quiz/Fluid_Mechanics.pdf
+++ b/sample_papers/MECH/2/quiz/Fluid_Mechanics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af7d2150456f188509ebeeabae26f92c9537bcadab5e6eb5199be0946ffa0129
+size 1238

--- a/sample_papers/MECH/2/quiz/Machine_Drawing.pdf
+++ b/sample_papers/MECH/2/quiz/Machine_Drawing.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae6878dce59e52655ed6a61de218f41677c423bd7b6d7d61589c7f70f31b0cfd
+size 1238

--- a/sample_papers/MECH/2/quiz/Manufacturing_Processes.pdf
+++ b/sample_papers/MECH/2/quiz/Manufacturing_Processes.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7f7299b5ae59eef05236ef552f3ec80cd77cac56f7cd8db929d46315443211e
+size 1253

--- a/sample_papers/MECH/2/quiz/Strength_of_Materials.pdf
+++ b/sample_papers/MECH/2/quiz/Strength_of_Materials.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ee78424040f152b8215923f5a2c129f55908b7319a7821978acb17087fb2056
+size 1249

--- a/sample_papers/MECH/2/quiz/Thermodynamics.pdf
+++ b/sample_papers/MECH/2/quiz/Thermodynamics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43ef8bf158d2752dc309c598524e882cc27a5d06f5c758ce1e9fa9156629556c
+size 1236

--- a/sample_papers/MECH/3/final/CAD/CAM.pdf
+++ b/sample_papers/MECH/3/final/CAD/CAM.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97adb42b5347f3238fab40cd865c9290954f8af0756c15a16558c64f79b6ebc5
+size 1233

--- a/sample_papers/MECH/3/final/Dynamics_of_Machines.pdf
+++ b/sample_papers/MECH/3/final/Dynamics_of_Machines.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bc2b6973579894b30ca13a3bbf8a18b1928a235a8f7d1e834797153b8632ca9
+size 1260

--- a/sample_papers/MECH/3/final/Heat_Transfer.pdf
+++ b/sample_papers/MECH/3/final/Heat_Transfer.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ecde0ba07be53c9142e73cca20d4fb4da3cad6c337ecb8a003e077b1ade48b2
+size 1242

--- a/sample_papers/MECH/3/final/Industrial_Engineering.pdf
+++ b/sample_papers/MECH/3/final/Industrial_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:182004d1e2626839f391e2cb4ea9aacf220a792db8a4c23dbdcd1a8fa265bdf8
+size 1260

--- a/sample_papers/MECH/3/final/Machine_Design.pdf
+++ b/sample_papers/MECH/3/final/Machine_Design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:148eb6c44a1f0bacd0c5c01916c237097d1f92f97abfc21e25084a5a43b4af94
+size 1244

--- a/sample_papers/MECH/3/mid/CAD/CAM.pdf
+++ b/sample_papers/MECH/3/mid/CAD/CAM.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53e199a845d0cae495e5e34094a7bc89ca6809683ee9869751ba25c3934cff49
+size 1237

--- a/sample_papers/MECH/3/mid/Dynamics_of_Machines.pdf
+++ b/sample_papers/MECH/3/mid/Dynamics_of_Machines.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d2f8585aed2f04b952830956f78947d6f603bd9c23cc177fecea8d6b2cad1f
+size 1261

--- a/sample_papers/MECH/3/mid/Heat_Transfer.pdf
+++ b/sample_papers/MECH/3/mid/Heat_Transfer.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b36574c5ecc3c33492365d90ab79f016f059fb671232053c22d7f99506040644
+size 1245

--- a/sample_papers/MECH/3/mid/Industrial_Engineering.pdf
+++ b/sample_papers/MECH/3/mid/Industrial_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a51a48dc9496ffbecf7fab28b91ef394ed3a08174bd845b25dc00eb07f29ff9
+size 1264

--- a/sample_papers/MECH/3/mid/Machine_Design.pdf
+++ b/sample_papers/MECH/3/mid/Machine_Design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e35948836cf192fecbc6f9375c7d4cf6d9d48fb114c31e2066b50b03d80507d7
+size 1248

--- a/sample_papers/MECH/3/mock/CAD/CAM.pdf
+++ b/sample_papers/MECH/3/mock/CAD/CAM.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cce0ba310fb01983666c162c8bfb2c8656a62d6281b31ef3f2efd7d5401891e
+size 1230

--- a/sample_papers/MECH/3/mock/Dynamics_of_Machines.pdf
+++ b/sample_papers/MECH/3/mock/Dynamics_of_Machines.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8da4aea47c94fd591070b37da8b2e112da70b8fc9af04e81d443792147e80926
+size 1260

--- a/sample_papers/MECH/3/mock/Heat_Transfer.pdf
+++ b/sample_papers/MECH/3/mock/Heat_Transfer.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a6b9ff7ae660007f379717de7cd7465c2df8b1f93d1f49e633ebeade6e61d39
+size 1240

--- a/sample_papers/MECH/3/mock/Industrial_Engineering.pdf
+++ b/sample_papers/MECH/3/mock/Industrial_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44e939f66a37c83f5d1681235cd13dfd3b94b4b6d7b65eb3340eefd8883a75a1
+size 1258

--- a/sample_papers/MECH/3/mock/Machine_Design.pdf
+++ b/sample_papers/MECH/3/mock/Machine_Design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8894fd0591469b72516e4d86269bfbb63b0fcdcd8c3456564d3d9e785ab03c7c
+size 1242

--- a/sample_papers/MECH/3/quiz/CAD/CAM.pdf
+++ b/sample_papers/MECH/3/quiz/CAD/CAM.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd13d98f49df0cde52928c9d4233bb7bd18fc98468c0b96cd3aa954b17a5805e
+size 1224

--- a/sample_papers/MECH/3/quiz/Dynamics_of_Machines.pdf
+++ b/sample_papers/MECH/3/quiz/Dynamics_of_Machines.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cb30351353a989bc44bff3909b38a64de839d23f307913723bfa41d732a4922
+size 1246

--- a/sample_papers/MECH/3/quiz/Heat_Transfer.pdf
+++ b/sample_papers/MECH/3/quiz/Heat_Transfer.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f92238612e22728d48e47854e669cf121ff04deb3d71b4d8316c6607cfa9db8b
+size 1232

--- a/sample_papers/MECH/3/quiz/Industrial_Engineering.pdf
+++ b/sample_papers/MECH/3/quiz/Industrial_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88522d3a94d854ad48968202eebaf23a1feb37844e977bd25e287bc210d7eb4d
+size 1251

--- a/sample_papers/MECH/3/quiz/Machine_Design.pdf
+++ b/sample_papers/MECH/3/quiz/Machine_Design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b737e36716329b0522e56b7b9a14f103b25c03ae76cf3096042093d0db387bf
+size 1235

--- a/sample_papers/MECH/4/final/Automobile_Engineering.pdf
+++ b/sample_papers/MECH/4/final/Automobile_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:869a42b5e16ed5fe92347ede9472d1fa04e3e8d82fd408f56da336aeb3a2a25e
+size 1261

--- a/sample_papers/MECH/4/final/Finite_Element_Analysis.pdf
+++ b/sample_papers/MECH/4/final/Finite_Element_Analysis.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e1a01bab09266e1866866759111bc18dea8836a0f9e5fcd8372524a69f65154
+size 1264

--- a/sample_papers/MECH/4/final/Project_Work.pdf
+++ b/sample_papers/MECH/4/final/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:781e097ad2b58759ec3479a35e97950f428fc5c36c850560923e4df20861cab3
+size 1242

--- a/sample_papers/MECH/4/final/Refrigeration_&_Air_Conditioning.pdf
+++ b/sample_papers/MECH/4/final/Refrigeration_&_Air_Conditioning.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8fc84305b7aa50bfbec76e0dcb619853664f3bffe8b74e385fad3516b7a036f3
+size 1282

--- a/sample_papers/MECH/4/final/Robotics.pdf
+++ b/sample_papers/MECH/4/final/Robotics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0600edf109b3ed47e3725b0b3a2a40e76a0488e34afdad7e1a7d9cbcadcc1641
+size 1235

--- a/sample_papers/MECH/4/mid/Automobile_Engineering.pdf
+++ b/sample_papers/MECH/4/mid/Automobile_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40ae8f976a6b58c7c874f99d617f066f52e00f98b8c8cb38691f4589f0fff560
+size 1265

--- a/sample_papers/MECH/4/mid/Finite_Element_Analysis.pdf
+++ b/sample_papers/MECH/4/mid/Finite_Element_Analysis.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12b6578e74bcda18e005e1a7eda8d68d925c002b6dda8c5ed636d81d8daa21d6
+size 1269

--- a/sample_papers/MECH/4/mid/Project_Work.pdf
+++ b/sample_papers/MECH/4/mid/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0e871cc2253e8d0b69f39538f68c720ef71046916bee653c9c8146e06a56db5
+size 1245

--- a/sample_papers/MECH/4/mid/Refrigeration_&_Air_Conditioning.pdf
+++ b/sample_papers/MECH/4/mid/Refrigeration_&_Air_Conditioning.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:346a39664ad0ee9d1696874184313b0ec6e97f6cdba0c3cf5934c670e163aa34
+size 1282

--- a/sample_papers/MECH/4/mid/Robotics.pdf
+++ b/sample_papers/MECH/4/mid/Robotics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5d1cb5cdae736d8d78b4793f261028ac15f32b99c61f8e0e3bd00f3cb69cc94
+size 1239

--- a/sample_papers/MECH/4/mock/Automobile_Engineering.pdf
+++ b/sample_papers/MECH/4/mock/Automobile_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5437460e271eae601ea7f692cf8b8177012a2cd918d0ef67aee81a1a92b3c4dc
+size 1259

--- a/sample_papers/MECH/4/mock/Finite_Element_Analysis.pdf
+++ b/sample_papers/MECH/4/mock/Finite_Element_Analysis.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3daf6f9a7bf7261f0674174c658ef13ce613152b43448209b1bebe281dd252af
+size 1262

--- a/sample_papers/MECH/4/mock/Project_Work.pdf
+++ b/sample_papers/MECH/4/mock/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f5463ea4f212b8c20efcae5533d4fb42c90fc8511adda9b5102f1a21d843041
+size 1239

--- a/sample_papers/MECH/4/mock/Refrigeration_&_Air_Conditioning.pdf
+++ b/sample_papers/MECH/4/mock/Refrigeration_&_Air_Conditioning.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2c8fc87d9043a25443ccd2f2523dbcf4525022fe4439f4c32c4b3a286d6c051
+size 1277

--- a/sample_papers/MECH/4/mock/Robotics.pdf
+++ b/sample_papers/MECH/4/mock/Robotics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ec096eac9d4de356238b0d2129ca0975b516ea32c49f67d5efc988bbc3a86b1
+size 1232

--- a/sample_papers/MECH/4/quiz/Automobile_Engineering.pdf
+++ b/sample_papers/MECH/4/quiz/Automobile_Engineering.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb04aeb85ad70128f978fdd2f88703c04279740087747bbf10df0ef869af8e60
+size 1252

--- a/sample_papers/MECH/4/quiz/Finite_Element_Analysis.pdf
+++ b/sample_papers/MECH/4/quiz/Finite_Element_Analysis.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b24120c9df10e4116271df7d7b39e933dfaa21056381bb55a5e453b9fb9e9805
+size 1254

--- a/sample_papers/MECH/4/quiz/Project_Work.pdf
+++ b/sample_papers/MECH/4/quiz/Project_Work.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ae4264b7fa0bef06e82ff3b87b2c0957054e92406f6bb11d2b5021cc9d5e717
+size 1233

--- a/sample_papers/MECH/4/quiz/Refrigeration_&_Air_Conditioning.pdf
+++ b/sample_papers/MECH/4/quiz/Refrigeration_&_Air_Conditioning.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d34b65563b4e6ea152c637836ad8dc5c169cd0236248eba14a6e63171e30546f
+size 1268

--- a/sample_papers/MECH/4/quiz/Robotics.pdf
+++ b/sample_papers/MECH/4/quiz/Robotics.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b87b3639886a20d80e8e3f17fc0075b7b3c9724ac4e07fcd6611c93dbe9abced
+size 1225


### PR DESCRIPTION
## Summary
- generate sample question papers automatically
- track generated PDFs via Git LFS
- dynamically fill subject dropdowns and provide download links in dashboard

## Testing
- `python3 -m py_compile generate_sample_papers.py`
- `python3 generate_sample_papers.py`

------
https://chatgpt.com/codex/tasks/task_e_687a7985d9c083329c8fb15aade037d9