### PR TITLE
Add client-side upload and PDF preview

### DIFF
--- a/admin_dashboard.html
+++ b/admin_dashboard.html
@@ -773,7 +773,7 @@
                             <input type="text" id="genTopics" class="form-control" placeholder="e.g., Processes, Memory Management, File Systems">
                         </div>
                         
-                        <button class="btn">
+                        <button id="generateBtn" class="btn">
                             <i class="fas fa-cogs"></i> Generate Paper
                         </button>
                         <a id="downloadSample" class="btn" href="#" style="display:none;" download>
@@ -871,6 +871,7 @@
         </div>
     </div>
     
+    <script src="js/app.js"></script>
     <script>
         // Navigation functionality
         document.querySelectorAll('.nav-links a').forEach(link => {
@@ -1020,9 +1021,6 @@
             if (year && branch && subject && type) {
                 const fileName = encodeURIComponent(subject.replace(/ /g, '_')) + '.pdf';
                 link.href = `sample_papers/${branch}/${year}/${type}/${fileName}`;
-                link.style.display = 'inline-block';
-            } else {
-                link.style.display = 'none';
             }
         }
 
@@ -1036,6 +1034,20 @@
         });
         document.getElementById('genSubject').addEventListener('change', updateDownloadLink);
         document.getElementById('genType').addEventListener('change', updateDownloadLink);
+
+        document.getElementById('generateBtn').addEventListener('click', async (e) => {
+            e.preventDefault();
+            const year = document.getElementById('genYear').value;
+            const branch = document.getElementById('genBranch').value;
+            const subject = document.getElementById('genSubject').value;
+            const type = document.getElementById('genType').value;
+            const link = document.getElementById('downloadSample');
+            if (!year || !branch || !subject || !type) {
+                alert('Please select all fields before generating the paper.');
+                return;
+            }
+            await QPF.generateAndOpenPDF({ year, branch, subject, type, downloadLink: link });
+        });
 
         document.getElementById('upYear').addEventListener('change', () => populateSubjects('upYear', 'upBranch', 'upSubject'));
         document.getElementById('upBranch').addEventListener('change', () => populateSubjects('upYear', 'upBranch', 'upSubject'));

--- a/home_page.html
+++ b/home_page.html
@@ -449,6 +449,9 @@
                 <button class="btn" onclick="generatePaper()">
                     <i class="fas fa-cogs"></i> Generate Question Paper
                 </button>
+                <a id="downloadLink" class="btn" href="#" style="display:none; margin-left:10px;" download>
+                    <i class="fas fa-download"></i> Download PDF
+                </a>
             </div>
             
             <div class="info-box">
@@ -480,6 +483,7 @@
             </div>
         </div>
     
+    <script src="js/app.js"></script>
     <script>
         // Subject database for B.Tech curriculum
         const subjectsDatabase = {
@@ -696,73 +700,25 @@
         }
 
         // Function to generate question paper
-        function generatePaper() {
+        async function generatePaper() {
             const year = yearSelect.value;
             const branch = branchSelect.value;
             const subject = subjectSelect.value;
             const paperType = document.getElementById('paperType').value;
-            
+
             if (!year || !branch || !subject) {
                 alert('Please select Year, Branch, and Subject before generating the paper.');
                 return;
             }
-            
-            // Success message with generated details
-            const paperTypes = {
-                'mid': 'Mid-Semester Exam',
-                'final': 'Final Exam',
-                'quiz': 'Quiz',
-                'mock': 'Mock Test'
-            };
-            
-            // Create a glass effect notification
-            const notification = document.createElement('div');
-            notification.style.cssText = `
-                position: fixed;
-                top: 20px;
-                left: 50%;
-                transform: translateX(-50%);
-                background: rgba(0, 0, 0, 0.7);
-                backdrop-filter: blur(10px);
-                color: white;
-                padding: 20px 40px;
-                border-radius: 12px;
-                border: 1px solid rgba(255, 255, 255, 0.2);
-                box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
-                z-index: 1000;
-                text-align: center;
-                animation: fadeIn 0.5s, fadeOut 0.5s 2.5s;
-            `;
-            
-            notification.innerHTML = `
-                <h3 style="margin-bottom: 10px; color: #4facfe;">Question Paper Generated!</h3>
-                <p>Year: ${yearSelect.options[yearSelect.selectedIndex].text}</p>
-                <p>Branch: ${branchSelect.options[branchSelect.selectedIndex].text}</p>
-                <p>Subject: ${subject}</p>
-                <p>Paper Type: ${paperTypes[paperType]}</p>
-            `;
-            
-            document.body.appendChild(notification);
-            
-            // Add CSS for animation
-            const style = document.createElement('style');
-            style.innerHTML = `
-                @keyframes fadeIn {
-                    from { opacity: 0; top: 0; }
-                    to { opacity: 1; top: 20px; }
-                }
-                @keyframes fadeOut {
-                    from { opacity: 1; top: 20px; }
-                    to { opacity: 0; top: 0; }
-                }
-            `;
-            document.head.appendChild(style);
-            
-            // Remove notification after animation
-            setTimeout(() => {
-                document.body.removeChild(notification);
-                document.head.removeChild(style);
-            }, 3000);
+
+            const downloadLink = document.getElementById('downloadLink');
+            await QPF.generateAndOpenPDF({
+                year,
+                branch,
+                subject,
+                type: paperType,
+                downloadLink
+            });
         }
 
         // Function to reset scroll position on page load

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,47 @@
+function sanitizeSubject(subject) {
+  return subject.trim().replace(/\s+/g, '_');
+}
+
+async function uploadPDF(options) {
+  const { year, branch, subject, type, file } = options;
+  if (!window.showDirectoryPicker) {
+    alert('Your browser does not support the File System Access API.');
+    return;
+  }
+  try {
+    const root = await window.showDirectoryPicker();
+    let dir = await root.getDirectoryHandle('sample_papers', { create: true });
+    dir = await dir.getDirectoryHandle(branch, { create: true });
+    dir = await dir.getDirectoryHandle(year, { create: true });
+    dir = await dir.getDirectoryHandle(type, { create: true });
+    const fileHandle = await dir.getFileHandle(sanitizeSubject(subject) + '.pdf', { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(await file.arrayBuffer());
+    await writable.close();
+    alert('PDF uploaded successfully!');
+  } catch (err) {
+    console.error(err);
+    alert('Failed to upload PDF.');
+  }
+}
+
+async function generateAndOpenPDF(options) {
+  const { year, branch, subject, type, downloadLink } = options;
+  const fileName = sanitizeSubject(subject) + '.pdf';
+  const path = `sample_papers/${branch}/${year}/${type}/${fileName}`;
+  try {
+    const res = await fetch(path);
+    if (!res.ok) throw new Error('Not found');
+    if (downloadLink) {
+      downloadLink.href = path;
+      downloadLink.download = fileName;
+      downloadLink.style.display = 'inline-block';
+    }
+    window.open(path, '_blank');
+  } catch (err) {
+    if (downloadLink) downloadLink.style.display = 'none';
+    alert('PDF not found');
+  }
+}
+
+window.QPF = { uploadPDF, generateAndOpenPDF, sanitizeSubject };

--- a/upload_paper.html
+++ b/upload_paper.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Upload Question Paper</title>
+  <style>
+    body {font-family: Arial, sans-serif; max-width: 600px; margin: 40px auto;}
+    label {display:block; margin-top:10px;}
+    input, select {width:100%; padding:8px; margin-top:4px;}
+    button {margin-top:15px; padding:10px 20px;}
+  </style>
+</head>
+<body>
+  <h2>Upload Question Paper</h2>
+  <form id="uploadForm">
+    <label>Academic Year
+      <select id="uYear" required>
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+      </select>
+    </label>
+    <label>Branch
+      <select id="uBranch" required>
+        <option value="CSE">CSE</option>
+        <option value="ECE">ECE</option>
+        <option value="MECH">MECH</option>
+        <option value="EEE">EEE</option>
+        <option value="CIVIL">CIVIL</option>
+      </select>
+    </label>
+    <label>Subject
+      <input id="uSubject" required placeholder="e.g. Mathematics-I">
+    </label>
+    <label>Paper Type
+      <select id="uType" required>
+        <option value="final">final</option>
+        <option value="mid">mid</option>
+        <option value="mock">mock</option>
+        <option value="quiz">quiz</option>
+      </select>
+    </label>
+    <label>PDF File
+      <input type="file" id="uFile" accept="application/pdf" required>
+    </label>
+    <button type="submit">Upload</button>
+  </form>
+  <p style="margin-top:20px; font-size:0.9em">This tool uses the File System Access API. Choose the <strong>project root directory</strong> when prompted.</p>
+  <script src="js/app.js"></script>
+  <script>
+    document.getElementById('uploadForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const file = document.getElementById('uFile').files[0];
+      if (!file) { alert('Select a PDF file'); return; }
+      await QPF.uploadPDF({
+        year: document.getElementById('uYear').value,
+        branch: document.getElementById('uBranch').value,
+        subject: document.getElementById('uSubject').value,
+        type: document.getElementById('uType').value,
+        file
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `js/app.js` with helper functions for uploading and previewing PDFs
- add `upload_paper.html` to let admins store PDFs locally using File System Access API
- enhance **Home** page: open PDF in new tab and offer a download link when generating papers
- enhance **Admin Dashboard**: same preview/download behavior and hook up Generate button

## Testing
- `python -m py_compile generate_sample_papers.py`


------
https://chatgpt.com/codex/tasks/task_e_687ae6a6b3fc8332a6a8fae8edd38f5c